### PR TITLE
fix: ensure blog page metadata renders in head instead of body

### DIFF
--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -8,22 +8,27 @@ import { AmbientBackground } from '@client/components/landing/AmbientBackground'
 import { BlogSearch } from '@client/components/blog/BlogSearch';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
-export const metadata: Metadata = {
-  title: 'Blog - Image Enhancement Tips & Guides',
-  description: `Learn about AI image upscaling, photo enhancement techniques, and tips for e-commerce product photography. Expert guides from ${clientEnv.APP_NAME}.`,
-  openGraph: {
-    title: `Blog - Image Enhancement Tips & Guides | ${clientEnv.APP_NAME}`,
-    description:
-      'Learn about AI image upscaling, photo enhancement techniques, and tips for e-commerce product photography.',
-  },
-};
-
-const POSTS_PER_PAGE = 6;
-
 interface IBlogPageProps {
   params: Promise<{ locale: string }>;
   searchParams: Promise<{ page?: string; q?: string }>;
 }
+
+export async function generateMetadata({ params }: IBlogPageProps): Promise<Metadata> {
+  await params;
+  const title = 'Blog - Image Enhancement Tips & Guides';
+  const description = `Learn about AI image upscaling, photo enhancement techniques, and tips for e-commerce product photography. Expert guides from ${clientEnv.APP_NAME}.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${title} | ${clientEnv.APP_NAME}`,
+      description,
+    },
+  };
+}
+
+const POSTS_PER_PAGE = 6;
 
 function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];


### PR DESCRIPTION
## Summary
- Convert static `metadata` export to `generateMetadata` function on the blog page
- Fixes Next.js 15 streaming issue where meta tags were appearing in the body after `</footer>`

## Problem
The `/blog` page had meta tags (`<title>`, `<meta name="description">`, `<link rel="manifest">`) appearing in the body instead of the head. This was visible when curling the page:
```html
</footer></div><script>...</script><title>Blog - Image Enhancement Tips...</title><meta name="description"...
```

## Root Cause
In Next.js 15, static metadata exports can be streamed late when pages use client components, causing metadata to flush to the body instead of the head during streaming.

## Solution
Use `generateMetadata` async function instead of static `metadata` export. This follows the same pattern used in the home page (`app/[locale]/page.tsx`) and ensures proper metadata placement in the `<head>` section.

## Test plan
- [x] Code follows existing project patterns
- [ ] Verify meta tags render in `<head>` on production after deploy
- [ ] `curl https://myimageupscaler.com/blog` shows no meta tags after `</footer>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)