### PR TITLE
fix(security): replace serverEnv with clientEnv in ErrorBoundary

### DIFF
--- a/client/components/errors/ErrorBoundary.tsx
+++ b/client/components/errors/ErrorBoundary.tsx
@@ -2,7 +2,7 @@
 
 import React, { Component, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
-import { serverEnv } from '@shared/config/env';
+import { clientEnv } from '@shared/config/env';
 import { useTranslations } from 'next-intl';
 
 // Extend Window interface for baselime monitoring
@@ -97,7 +97,7 @@ class ErrorBoundaryInner extends Component<
               </h1>
               <p className="mt-2 text-text-secondary">{this.props.t('errors.boundary.message')}</p>
 
-              {serverEnv.ENV === 'development' && this.state.error && (
+              {clientEnv.ENV === 'development' && this.state.error && (
                 <details className="mt-4 text-left">
                   <summary className="cursor-pointer text-sm text-text-secondary hover:text-text-muted">
                     {this.props.t('errors.boundary.detailsLabel')}


### PR DESCRIPTION
## Summary
CRITICAL SECURITY: ErrorBoundary was importing `serverEnv` in a 'use client' component. This leaked sensitive environment variables (STRIPE_SECRET_KEY, SUPABASE_SERVICE_ROLE_KEY, etc.) to the client bundle.

## Fix
- Changed `import { serverEnv }` to `import { clientEnv }`
- Changed `serverEnv.ENV === 'development'` to `clientEnv.ENV === 'development'`

## Ticket
XenonFlow: t-1769848093069-lpjg9paf1

## Testing
- [x] `yarn verify` passes (1079 warnings, 0 errors)
- [x] TypeScript compiles cleanly
- [x] API tests pass (250/251)
- [ ] E2E tests (skipped - unrelated OOM issue)

## Root Cause
ErrorBoundary.tsx had `'use client'` directive but imported `serverEnv` which contains server-only secrets. Next.js bundled the entire serverEnv object into the client JavaScript.

## Impact
Anyone viewing page source or using dev tools could see:
- STRIPE_SECRET_KEY
- SUPABASE_SERVICE_ROLE_KEY
- REPLICATE_API_TOKEN
- And other sensitive API keys

## Prevention
CLAUDE.md already warns: *"NEVER use process.env directly. Use clientEnv or serverEnv from @shared/config/env"*
But this should be enforced via ESLint rule to prevent `serverEnv` imports in 'use client' files.