### PR TITLE
fix(seo): use locale-specific canonical URLs for hreflang pages

### DIFF
--- a/lib/seo/hreflang-generator.ts
+++ b/lib/seo/hreflang-generator.ts
@@ -158,12 +158,12 @@ export function formatHreflangForMetadata(
 
 /**
  * Generate canonical URL for a page
- * IMPORTANT: All localized pages canonicalize to the English version
- * This is the SEO best practice for multi-language sites
+ * Each localized page has its own canonical URL (self-referencing)
+ * This is required when using hreflang to avoid "hreflang to non-canonical pages" SEO issue
  *
  * @param path - The page path without locale prefix (e.g., '/tools/ai-upscaler')
- * @param locale - The locale of the page (default: 'en') - NOT used for canonical URL
- * @returns Full canonical URL (always English version)
+ * @param locale - The locale of the page (default: 'en')
+ * @returns Full canonical URL for the specified locale
  *
  * @example
  * ```ts
@@ -171,26 +171,25 @@ export function formatHreflangForMetadata(
  * // Returns: 'https://myimageupscaler.com/tools/ai-upscaler'
  *
  * getCanonicalUrl('/tools/ai-upscaler', 'es');
- * // Returns: 'https://myimageupscaler.com/tools/ai-upscaler' (same!)
+ * // Returns: 'https://myimageupscaler.com/es/tools/ai-upscaler'
  *
  * getCanonicalUrl('/', 'es');
- * // Returns: 'https://myimageupscaler.com'
+ * // Returns: 'https://myimageupscaler.com/es'
  * ```
  */
-export function getCanonicalUrl(path: string, _locale: Locale = DEFAULT_LOCALE): string {
+export function getCanonicalUrl(path: string, locale: Locale = DEFAULT_LOCALE): string {
   // Remove trailing slash for consistency
   const normalizedPath = path.replace(/\/$/, '') || '/';
 
-  // Always use the English version for canonical URL
-  // This ensures all localized variations point to the same canonical
-  const englishPath = getLocalizedPath(normalizedPath, DEFAULT_LOCALE);
+  // Get the localized path (includes locale prefix for non-English)
+  const localizedPath = getLocalizedPath(normalizedPath, locale);
 
-  // For root path, return BASE_URL without trailing slash
-  if (englishPath === '/' || englishPath === '') {
+  // For root path with default locale, return BASE_URL without trailing slash
+  if (localizedPath === '/' || localizedPath === '') {
     return clientEnv.BASE_URL;
   }
 
-  return `${clientEnv.BASE_URL}${englishPath}`;
+  return `${clientEnv.BASE_URL}${localizedPath}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes the 'hreflang to non-canonical pages' SEO issue where localized pages (e.g., Spanish) were pointing to English-only canonical URLs.

## Problem
Previously, all localized pages canonicalized to the English version:
- `/es/tools/ai-upscaler` → canonical: `/tools/ai-upscaler`

This causes SEO issues when Google sees hreflang pointing to a page whose canonical differs from the hreflang target.

## Solution  
Each locale now has its own self-referencing canonical URL:
- `/tools/ai-upscaler` (en) → canonical: `/tools/ai-upscaler`
- `/es/tools/ai-upscaler` → canonical: `/es/tools/ai-upscaler`

## Testing
- ✅ All 6 SEO metadata E2E tests pass (including the Spanish canonical test)
- ✅ `yarn verify` passes
- ✅ All 250 API tests pass

## Ticket
Unblocks the Guest Upscaler PR which was blocked by this test failure.