### PR TITLE
feat: UX & conversion optimization — data-driven improvements (#10)

### DIFF
--- a/app/api/analytics/event/route.ts
+++ b/app/api/analytics/event/route.ts
@@ -52,6 +52,11 @@ const ALLOWED_EVENTS = [
   'batch_limit_partial_add_clicked',
   'batch_limit_modal_closed',
 
+  // Upgrade prompt events
+  'upgrade_prompt_shown',
+  'upgrade_prompt_clicked',
+  'upgrade_prompt_dismissed',
+
   // pSEO-specific events
   'pseo_page_view',
   'pseo_cta_clicked',

--- a/client/components/features/image-processing/ImageComparison.tsx
+++ b/client/components/features/image-processing/ImageComparison.tsx
@@ -1,6 +1,15 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { ArrowLeftRight, Download, ZoomIn, ZoomOut } from 'lucide-react';
+import Link from 'next/link';
 import { Button } from '@client/components/ui/Button';
+import { canShowPrompt, markPromptShown } from '@client/utils/promptFrequency';
+import type { IPromptFrequencyConfig } from '@client/utils/promptFrequency';
+import { analytics } from '@client/analytics/analyticsClient';
+
+const AFTER_COMPARISON_FREQ_CONFIG: IPromptFrequencyConfig = {
+  key: 'prompt_freq_after_comparison',
+  cooldownMs: 48 * 60 * 60 * 1000,
+};
 
 interface IImageComparisonProps {
   beforeUrl: string;
@@ -19,11 +28,24 @@ export const ImageComparison: React.FC<IImageComparisonProps> = ({
   const [sliderPosition, setSliderPosition] = useState(50);
   const [isDragging, setIsDragging] = useState(false);
   const [zoom, setZoom] = useState(1);
+  const [showComparisonNudge, setShowComparisonNudge] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Auto-detect transparency from blob URL if not explicitly provided
   // Blob URLs indicate client-side processing (e.g., bg-removal) which produces transparent PNGs
   const showTransparency = hasTransparency ?? afterUrl.startsWith('blob:');
+
+  // Show upgrade nudge once after the user has moved the comparison slider,
+  // subject to cross-session frequency capping (48-hour cooldown).
+  useEffect(() => {
+    if (!isDragging && sliderPosition !== 50) {
+      if (canShowPrompt(AFTER_COMPARISON_FREQ_CONFIG)) {
+        setShowComparisonNudge(true);
+        markPromptShown(AFTER_COMPARISON_FREQ_CONFIG);
+        analytics.track('upgrade_prompt_shown', { trigger: 'after_comparison' });
+      }
+    }
+  }, [isDragging, sliderPosition]);
 
   const handleMouseDown = useCallback(() => {
     setIsDragging(true);
@@ -154,6 +176,15 @@ export const ImageComparison: React.FC<IImageComparisonProps> = ({
           Enhanced
         </div>
       </div>
+
+      {showComparisonNudge && (
+        <div className="px-4 py-2 border-t border-border text-center text-xs text-text-muted">
+          Unlock premium models for even sharper results.{' '}
+          <Link href="/dashboard/billing" className="text-accent hover:underline font-medium">
+            Upgrade now
+          </Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/client/components/features/workspace/BatchLimitModal.tsx
+++ b/client/components/features/workspace/BatchLimitModal.tsx
@@ -55,7 +55,7 @@ export const BatchLimitModal: React.FC<IBatchLimitModalProps> = ({
       userType: limit <= 5 ? 'free' : 'paid',
       source: 'batch_limit_modal',
     });
-    router.push('/pricing');
+    router.push('/dashboard/billing');
   };
 
   const handleAddPartial = () => {
@@ -134,7 +134,7 @@ export const BatchLimitModal: React.FC<IBatchLimitModalProps> = ({
       {/* Action Buttons */}
       <div className="space-y-3">
         <Button variant="primary" className="w-full" onClick={handleUpgradeClick}>
-          {t('upgradeButton')}
+          {t('unlockBatchButton')}
         </Button>
 
         {!serverEnforced && availableSlots > 0 && (

--- a/client/components/features/workspace/ModelCard.tsx
+++ b/client/components/features/workspace/ModelCard.tsx
@@ -89,6 +89,20 @@ export const ModelCard: React.FC<IModelCardProps> = ({
             <span className="text-[8px] font-bold text-amber-300 uppercase tracking-wide">Pro</span>
           </div>
         )}
+
+        {/* Popularity/recommendation badge */}
+        {config.badge && (
+          <div
+            className={cn(
+              'absolute top-1.5 right-1.5 z-10 px-1.5 py-0.5 rounded-full text-[8px] font-black uppercase tracking-wide',
+              config.badge === 'popular'
+                ? 'bg-amber-500/90 text-white'
+                : 'bg-emerald-500/90 text-white'
+            )}
+          >
+            {config.badge === 'popular' ? 'Popular' : 'Recommended'}
+          </div>
+        )}
       </div>
 
       {/* Card Content Section */}

--- a/client/components/features/workspace/ModelGalleryModal.tsx
+++ b/client/components/features/workspace/ModelGalleryModal.tsx
@@ -63,10 +63,14 @@ export const ModelGalleryModal: React.FC<IModelGalleryModalProps> = ({
     });
   }, [allTiers, searchQuery]);
 
-  // Separate into free and premium tiers
+  // Separate into free and premium tiers, sorted by popularity (descending)
   const { freeTiers, premiumTiers } = useMemo(() => {
-    const free = filteredTiers.filter(t => FREE_TIERS.includes(t.id));
-    const premium = filteredTiers.filter(t => PREMIUM_TIERS.includes(t.id));
+    const free = filteredTiers
+      .filter(t => FREE_TIERS.includes(t.id))
+      .sort((a, b) => (b.popularity ?? 50) - (a.popularity ?? 50));
+    const premium = filteredTiers
+      .filter(t => PREMIUM_TIERS.includes(t.id))
+      .sort((a, b) => (b.popularity ?? 50) - (a.popularity ?? 50));
     return { freeTiers: free, premiumTiers: premium };
   }, [filteredTiers]);
 

--- a/client/components/features/workspace/PostDownloadPrompt.tsx
+++ b/client/components/features/workspace/PostDownloadPrompt.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { X, Sparkles } from 'lucide-react';
+import { analytics } from '@client/analytics/analyticsClient';
+import { canShowPrompt, markPromptShown } from '@client/utils/promptFrequency';
+import { cn } from '@client/utils/cn';
+
+const POST_DOWNLOAD_FREQ_CONFIG = {
+  key: 'post_download_prompt_last_shown',
+  cooldownMs: 72 * 60 * 60 * 1000, // 72 hours
+};
+
+const SESSION_KEY = 'upgrade_prompt_shown_after_download';
+
+export interface IPostDownloadPromptProps {
+  isFreeUser: boolean;
+  downloadCount: number;
+}
+
+export const PostDownloadPrompt: React.FC<IPostDownloadPromptProps> = ({
+  isFreeUser,
+  downloadCount,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Only show for free users after at least 1 download
+    if (!isFreeUser || downloadCount < 1) return;
+
+    // Session throttle: once per session
+    if (typeof window !== 'undefined' && sessionStorage.getItem(SESSION_KEY) === 'true') return;
+
+    // Cross-session cooldown: 72h via localStorage
+    if (!canShowPrompt(POST_DOWNLOAD_FREQ_CONFIG)) return;
+
+    setVisible(true);
+    markPromptShown(POST_DOWNLOAD_FREQ_CONFIG);
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem(SESSION_KEY, 'true');
+    }
+    analytics.track('upgrade_prompt_shown', { trigger: 'after_download' });
+  }, [isFreeUser, downloadCount]);
+
+  if (!visible || dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    analytics.track('upgrade_prompt_dismissed', { trigger: 'after_download' });
+  };
+
+  const handleCtaClick = () => {
+    analytics.track('upgrade_prompt_clicked', { trigger: 'after_download' });
+  };
+
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-xl border border-accent/30 bg-accent/5 px-4 py-3',
+        'flex items-center gap-3',
+        'animate-fade-in-up'
+      )}
+      data-testid="post-download-prompt"
+    >
+      <Sparkles className="h-4 w-4 text-accent shrink-0" />
+      <p className="flex-1 text-xs font-medium text-white/80">
+        Love the result?{' '}
+        <span className="text-white font-bold">Get 10x sharper with Premium models.</span>
+      </p>
+      <Link
+        href="/dashboard/billing"
+        onClick={handleCtaClick}
+        className="shrink-0 text-xs font-black uppercase tracking-wide text-accent hover:text-accent/80 transition-colors"
+        data-testid="post-download-prompt-cta"
+      >
+        See Premium Plans
+      </Link>
+      <button
+        onClick={handleDismiss}
+        className="shrink-0 text-white/40 hover:text-white/70 transition-colors p-0.5"
+        aria-label="Dismiss upgrade prompt"
+        data-testid="post-download-prompt-dismiss"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+};

--- a/client/components/features/workspace/UpgradeSuccessBanner.tsx
+++ b/client/components/features/workspace/UpgradeSuccessBanner.tsx
@@ -2,7 +2,15 @@
 
 import { Sparkles, X } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { analytics } from '@client/analytics/analyticsClient';
+import { canShowPrompt, markPromptShown } from '@client/utils/promptFrequency';
+import type { IPromptFrequencyConfig } from '@client/utils/promptFrequency';
+
+const AFTER_BATCH_FREQ_CONFIG: IPromptFrequencyConfig = {
+  key: 'prompt_freq_after_batch',
+  cooldownMs: 24 * 60 * 60 * 1000,
+};
 
 export interface IUpgradeSuccessBannerProps {
   processedCount: number;
@@ -22,16 +30,32 @@ export const UpgradeSuccessBanner = ({
     return false;
   });
 
+  useEffect(() => {
+    if (!dismissed && !hasSubscription && canShowPrompt(AFTER_BATCH_FREQ_CONFIG)) {
+      analytics.track('upgrade_prompt_shown', { trigger: 'after_batch' });
+      markPromptShown(AFTER_BATCH_FREQ_CONFIG);
+    }
+  }, [dismissed, hasSubscription]);
+
   if (dismissed || hasSubscription) {
     return null;
   }
 
+  if (!canShowPrompt(AFTER_BATCH_FREQ_CONFIG)) {
+    return null;
+  }
+
   const handleDismiss = () => {
+    analytics.track('upgrade_prompt_dismissed', { trigger: 'after_batch' });
     if (typeof window !== 'undefined') {
       sessionStorage.setItem('upgrade-banner-dismissed', 'true');
     }
     setDismissed(true);
     onDismiss();
+  };
+
+  const handleSeePlansClick = () => {
+    analytics.track('upgrade_prompt_clicked', { trigger: 'after_batch' });
   };
 
   return (
@@ -67,7 +91,8 @@ export const UpgradeSuccessBanner = ({
           </p>
           <div className="mt-4 flex flex-wrap items-center justify-center sm:justify-start gap-5">
             <Link
-              href="/pricing"
+              href="/dashboard/billing"
+              onClick={handleSeePlansClick}
               className="gradient-cta shine-effect px-6 py-2 rounded-xl text-[10px] font-black uppercase tracking-wider text-white shadow-lg active:scale-95 transition-transform"
             >
               See Plans

--- a/client/components/features/workspace/Workspace.tsx
+++ b/client/components/features/workspace/Workspace.tsx
@@ -23,6 +23,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { BatchLimitModal } from './BatchLimitModal';
 import { ModelGalleryModal } from './ModelGalleryModal';
+import { PostDownloadPrompt } from './PostDownloadPrompt';
 import { UpgradeSuccessBanner } from './UpgradeSuccessBanner';
 
 type MobileTab = 'upload' | 'preview' | 'queue';
@@ -70,6 +71,9 @@ const Workspace: React.FC = () => {
       enhancement: DEFAULT_ENHANCEMENT_SETTINGS,
     },
   });
+
+  // Download count state for post-download upgrade prompt
+  const [downloadCount, setDownloadCount] = useState(0);
 
   // Success banner state
   const [showSuccessBanner, setShowSuccessBanner] = useState(false);
@@ -143,6 +147,7 @@ const Workspace: React.FC = () => {
     try {
       setDownloadError(null);
       await downloadSingle(url, filename, config.qualityTier);
+      setDownloadCount(prev => prev + 1);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : t('workspace.downloadError.title');
@@ -282,6 +287,13 @@ const Workspace: React.FC = () => {
               isProcessingBatch={isProcessingBatch}
             />
           </div>
+
+          {/* Post-download upgrade prompt */}
+          {!showSuccessBanner && (
+            <div className="px-3 pb-2">
+              <PostDownloadPrompt isFreeUser={isFreeUser} downloadCount={downloadCount} />
+            </div>
+          )}
 
           {/* Queue Strip at bottom */}
           <div className="hidden md:block">

--- a/client/utils/promptFrequency.ts
+++ b/client/utils/promptFrequency.ts
@@ -1,0 +1,80 @@
+/**
+ * Cross-session frequency capping for upgrade prompts.
+ * Uses localStorage to prevent prompt fatigue across browser sessions.
+ */
+
+export interface IPromptFrequencyConfig {
+  key: string; // localStorage key
+  cooldownMs: number; // Minimum time between shows
+  maxPerWeek?: number; // Optional weekly cap
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface IPromptStats {
+  lastShown: number | null;
+  weeklyCount: number;
+  weekStart: number;
+}
+
+function getStats(key: string): IPromptStats {
+  if (typeof window === 'undefined') {
+    return { lastShown: null, weeklyCount: 0, weekStart: Date.now() };
+  }
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return { lastShown: null, weeklyCount: 0, weekStart: Date.now() };
+    return JSON.parse(raw) as IPromptStats;
+  } catch {
+    return { lastShown: null, weeklyCount: 0, weekStart: Date.now() };
+  }
+}
+
+export function canShowPrompt(config: IPromptFrequencyConfig): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const stats = getStats(config.key);
+  const now = Date.now();
+
+  // Check cooldown
+  if (stats.lastShown !== null && now - stats.lastShown < config.cooldownMs) {
+    return false;
+  }
+
+  // Check weekly cap
+  if (config.maxPerWeek !== undefined) {
+    const weekStart = now - WEEK_MS;
+    const currentWeekCount = stats.weekStart > weekStart ? stats.weeklyCount : 0;
+    if (currentWeekCount >= config.maxPerWeek) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function markPromptShown(config: IPromptFrequencyConfig): void {
+  if (typeof window === 'undefined') return;
+
+  const now = Date.now();
+  const stats = getStats(config.key);
+  const weekStart = now - WEEK_MS;
+  const currentWeekCount = stats.weekStart > weekStart ? stats.weeklyCount : 0;
+
+  const updated: IPromptStats = {
+    lastShown: now,
+    weeklyCount: currentWeekCount + 1,
+    weekStart: stats.weekStart > weekStart ? stats.weekStart : now,
+  };
+
+  try {
+    localStorage.setItem(config.key, JSON.stringify(updated));
+  } catch {
+    // localStorage may be unavailable (private browsing, quota exceeded)
+  }
+}
+
+export function getPromptStats(key: string): { lastShown: number | null; weeklyCount: number } {
+  const stats = getStats(key);
+  return { lastShown: stats.lastShown, weeklyCount: stats.weeklyCount };
+}

--- a/locales/en/workspace.json
+++ b/locales/en/workspace.json
@@ -7,6 +7,7 @@
     "freeUserMessage": "Free users can process 1 image at a time. Upgrade to unlock higher batch limits and process multiple images.",
     "securityMessage": "This is a security measure to prevent abuse. The limit will reset in approximately 1 hour. Upgrade your plan for higher limits.",
     "upgradeButton": "Upgrade Plan",
+    "unlockBatchButton": "Unlock Batch Processing",
     "addPartialButton": "Add {availableSlots} {count, plural, one {image} other {images}}",
     "cancelButton": "Cancel"
   },

--- a/server/analytics/types.ts
+++ b/server/analytics/types.ts
@@ -148,6 +148,10 @@ export type IAnalyticsEventName =
   | 'batch_limit_upgrade_clicked'
   | 'batch_limit_partial_add_clicked'
   | 'batch_limit_modal_closed'
+  // Upgrade prompt events
+  | 'upgrade_prompt_shown'
+  | 'upgrade_prompt_clicked'
+  | 'upgrade_prompt_dismissed'
   // pSEO-specific events
   | 'pseo_page_view'
   | 'pseo_cta_clicked'

--- a/shared/types/coreflow.types.ts
+++ b/shared/types/coreflow.types.ts
@@ -52,6 +52,8 @@ export const QUALITY_TIER_CONFIG: Record<
     previewImages: IPreviewImages | null; // Before/after thumbnails for gallery
     customPrompt?: string; // Optional tier-specific prompt (overrides model default, but user customInstructions still win)
     genericPromptOverride?: boolean; // When true, customPrompt replaces the entire prompt (no generic modifiers appended). When false/unset, customPrompt is used as base and merged with generic modifiers.
+    badge?: 'popular' | 'recommended' | null;
+    popularity?: number; // 1-100 for sorting, higher = more popular
   }
 > = {
   auto: {
@@ -67,6 +69,7 @@ export const QUALITY_TIER_CONFIG: Record<
       after: '/before-after/auto/preview.webp',
       displayMode: 'static',
     },
+    popularity: 50,
   },
   quick: {
     label: 'Light Blur Fix',
@@ -80,6 +83,8 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/quick/before.webp',
       after: '/before-after/quick/after.webp',
     },
+    badge: 'popular',
+    popularity: 90,
   },
   'budget-edit': {
     label: 'Standard Enhance',
@@ -94,6 +99,7 @@ export const QUALITY_TIER_CONFIG: Record<
       after: '/before-after/budget-edit/after.webp',
       objectPosition: 'center 20%',
     },
+    popularity: 70,
   },
   'face-pro': {
     label: 'Portrait Pro',
@@ -108,6 +114,7 @@ export const QUALITY_TIER_CONFIG: Record<
       after: '/before-after/face-pro/after.webp',
       objectPosition: 'center 25%',
     },
+    popularity: 50,
   },
   'seedream-edit': {
     label: 'Creative Edit',
@@ -121,6 +128,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/seedream-edit/before.webp',
       after: '/before-after/seedream-edit/after.webp',
     },
+    popularity: 50,
   },
   'face-restore': {
     label: 'Face Restore',
@@ -134,6 +142,8 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/face-restore/before.webp',
       after: '/before-after/face-restore/after.webp',
     },
+    badge: 'recommended',
+    popularity: 80,
   },
   'fast-edit': {
     label: 'Quick Enhance',
@@ -147,6 +157,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/fast-edit/before.webp',
       after: '/before-after/fast-edit/after.webp',
     },
+    popularity: 50,
   },
   'budget-old-photo': {
     label: 'Old Photo Fix',
@@ -160,6 +171,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/budget-old-photo/before.webp',
       after: '/before-after/budget-old-photo/after.webp',
     },
+    popularity: 50,
     customPrompt:
       'Restore this old or damaged photo. Fix fading, color degradation, and minor scratches or blemishes. Recover natural skin tones and colors while preserving the original composition and character of the photograph.',
     genericPromptOverride: true,
@@ -176,6 +188,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/anime-upscale/before.webp',
       after: '/before-after/anime-upscale/after.webp',
     },
+    popularity: 50,
   },
   'hd-upscale': {
     label: 'HD Upscale',
@@ -189,6 +202,8 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/hd-upscale/before.webp',
       after: '/before-after/hd-upscale/after.webp',
     },
+    badge: 'popular',
+    popularity: 75,
   },
   ultra: {
     label: 'Ultra Upscale',
@@ -202,6 +217,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/ultra/before.webp',
       after: '/before-after/ultra/after.webp',
     },
+    popularity: 50,
   },
   'bg-removal': {
     label: 'Background Removal',
@@ -215,6 +231,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/bg-removal/before.webp',
       after: '/before-after/bg-removal/after.webp',
     },
+    popularity: 50,
   },
   'lighting-fix': {
     label: 'Lighting Fix',
@@ -228,6 +245,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/lighting-fix/before.webp',
       after: '/before-after/lighting-fix/after.webp',
     },
+    popularity: 50,
     customPrompt:
       'Fix the lighting in this image. Correct underexposure or overexposure, balance shadows and highlights, and normalize the overall luminance so the subject is clearly visible. Preserve the original colors and composition exactly — only adjust lighting, exposure and artifacts.',
     genericPromptOverride: true,
@@ -245,6 +263,7 @@ export const QUALITY_TIER_CONFIG: Record<
       after: '/before-after/resume-photo/after.webp',
       displayMode: 'flip',
     },
+    popularity: 50,
     customPrompt:
       'Transform this photo into a professional corporate headshot suitable for a resume or LinkedIn profile. Replace clothes with a suite. Remove any background and place the subject against a solid white background. Ensure even, flattering lighting on the face. Smooth minor skin blemishes while keeping the person looking natural and recognizable. Maintain a sharp focus on the face and upper body. The result should look like a studio-quality professional portrait.',
     genericPromptOverride: true,
@@ -268,6 +287,7 @@ export const QUALITY_TIER_CONFIG: Record<
       before: '/before-after/photo-repair/before.webp',
       after: '/before-after/photo-repair/after.webp',
     },
+    popularity: 50,
     customPrompt:
       'Repair this physically damaged photograph. Preserve original structure and dimensions. Reconstruct any torn, missing, or destroyed areas by intelligently filling in the gaps based on surrounding context. Remove scratches, cracks, water stains, and other physical damage marks. Restore the image to look as if it was never damaged. Preserve the original content, colors, and composition exactly — only repair the physical damage.',
   },

--- a/tests/unit/client/model-gallery-modal.unit.spec.tsx
+++ b/tests/unit/client/model-gallery-modal.unit.spec.tsx
@@ -333,6 +333,93 @@ describe('ModelCard', () => {
   });
 });
 
+describe('badges and sorting', () => {
+  const mockOnSelect = vi.fn();
+  const mockOnLockedClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render Popular badge on quick tier', () => {
+    render(
+      <ModelCard
+        tier="quick"
+        config={QUALITY_TIER_CONFIG['quick']}
+        isSelected={false}
+        isLocked={false}
+        onSelect={mockOnSelect}
+        onLockedClick={mockOnLockedClick}
+      />
+    );
+
+    expect(screen.getByText('Popular')).toBeInTheDocument();
+  });
+
+  it('should render Recommended badge on face-restore tier', () => {
+    render(
+      <ModelCard
+        tier="face-restore"
+        config={QUALITY_TIER_CONFIG['face-restore']}
+        isSelected={false}
+        isLocked={false}
+        onSelect={mockOnSelect}
+        onLockedClick={mockOnLockedClick}
+      />
+    );
+
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+  });
+
+  it('should sort tiers by popularity within sections', () => {
+    const mockOnClose = vi.fn();
+
+    render(
+      <ModelGalleryModal
+        isOpen={true}
+        onClose={mockOnClose}
+        currentTier="auto"
+        isFreeUser={false}
+        onSelect={mockOnSelect}
+      />
+    );
+
+    // Find all bold label spans in the free section (Available section)
+    // quick tier (Light Blur Fix, popularity 90) should appear before face-restore (80)
+    // which should appear before bg-removal (50)
+    const allLabels = document.querySelectorAll('span.font-bold.text-xs');
+    const labelTexts = Array.from(allLabels).map(el => el.textContent);
+
+    const lightBlurFixIndex = labelTexts.indexOf('Light Blur Fix');
+    const faceRestoreIndex = labelTexts.indexOf('Face Restore');
+    const bgRemovalIndex = labelTexts.indexOf('Background Removal');
+
+    // Light Blur Fix (quick, popularity 90) should be first in free tiers
+    expect(lightBlurFixIndex).toBeGreaterThanOrEqual(0);
+    expect(faceRestoreIndex).toBeGreaterThanOrEqual(0);
+    expect(bgRemovalIndex).toBeGreaterThanOrEqual(0);
+    expect(lightBlurFixIndex).toBeLessThan(faceRestoreIndex);
+    expect(faceRestoreIndex).toBeLessThan(bgRemovalIndex);
+  });
+
+  it('should not render badge when badge is null/undefined', () => {
+    render(
+      <ModelCard
+        tier="auto"
+        config={QUALITY_TIER_CONFIG['auto']}
+        isSelected={false}
+        isLocked={false}
+        onSelect={mockOnSelect}
+        onLockedClick={mockOnLockedClick}
+      />
+    );
+
+    // The auto tier has no badge, so neither "Popular" nor "Recommended" should appear
+    expect(screen.queryByText('Popular')).not.toBeInTheDocument();
+    expect(screen.queryByText('Recommended')).not.toBeInTheDocument();
+  });
+});
+
 describe('ModelGallerySearch', () => {
   const mockOnChange = vi.fn();
   const defaultSearchProps = {

--- a/tests/unit/client/upgrade-prompts.unit.spec.tsx
+++ b/tests/unit/client/upgrade-prompts.unit.spec.tsx
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for upgrade prompt components: BatchLimitModal, UpgradeSuccessBanner, PostDownloadPrompt
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+// Mock next/link - render an <a> element forwarding all props (including data-testid)
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock next-intl - return a function that returns the key as-is
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  AlertTriangle: () => <span data-testid="alert-triangle-icon">AlertTriangle</span>,
+  Sparkles: () => <span data-testid="sparkles-icon">Sparkles</span>,
+  X: () => <span data-testid="x-icon">X</span>,
+}));
+
+// Mock @client/components/ui/Modal - render children when isOpen is true
+vi.mock('@client/components/ui/Modal', () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+// Mock @client/components/ui/Button - render a button with children
+vi.mock('@client/components/ui/Button', () => ({
+  Button: ({
+    children,
+    onClick,
+    className,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    className?: string;
+  }) => (
+    <button onClick={onClick} className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+// Mock analytics - use vi.hoisted to avoid "before initialization" error
+const { mockAnalyticsTrack } = vi.hoisted(() => ({
+  mockAnalyticsTrack: vi.fn(),
+}));
+vi.mock('@client/analytics/analyticsClient', () => ({
+  analytics: {
+    track: mockAnalyticsTrack,
+  },
+}));
+
+// Import components after mocks
+import { BatchLimitModal } from '@client/components/features/workspace/BatchLimitModal';
+import { UpgradeSuccessBanner } from '@client/components/features/workspace/UpgradeSuccessBanner';
+import { PostDownloadPrompt } from '@client/components/features/workspace/PostDownloadPrompt';
+
+describe('BatchLimitModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    limit: 1,
+    attempted: 2,
+    currentCount: 0,
+    onAddPartial: vi.fn(),
+    serverEnforced: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should show "Unlock Batch Processing" button text in BatchLimitModal', () => {
+    render(<BatchLimitModal {...defaultProps} />);
+
+    // The translation mock returns the key as-is, so t('unlockBatchButton') → 'unlockBatchButton'
+    expect(screen.getByText('unlockBatchButton')).toBeInTheDocument();
+  });
+
+  it('should show free user specific copy when limit is 1', () => {
+    render(<BatchLimitModal {...defaultProps} limit={1} />);
+
+    // When limit === 1, the component renders a free user message box
+    // The mock returns the key 'freeUserMessage' as text
+    expect(screen.getByText('freeUserMessage')).toBeInTheDocument();
+  });
+});
+
+describe('UpgradeSuccessBanner', () => {
+  const defaultProps = {
+    processedCount: 3,
+    onDismiss: vi.fn(),
+    hasSubscription: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear sessionStorage between tests so dismissed state doesn't carry over
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem('upgrade-banner-dismissed');
+    }
+    // localStorage is a global mock (vi.fn()) — getItem returns undefined by default
+    // after vi.clearAllMocks(), so canShowPrompt will return true (no cooldown set)
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should link to /dashboard/billing', () => {
+    render(<UpgradeSuccessBanner {...defaultProps} />);
+
+    const link = screen.getByRole('link', { name: /see plans/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/dashboard/billing');
+  });
+
+  it('should fire upgrade_prompt_shown on mount', async () => {
+    render(<UpgradeSuccessBanner {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockAnalyticsTrack).toHaveBeenCalledWith('upgrade_prompt_shown', {
+        trigger: 'after_batch',
+      });
+    });
+  });
+});
+
+describe('PostDownloadPrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // localStorage is globally mocked as vi.fn() in vitest.setup.tsx.
+    // vi.clearAllMocks() clears call history but NOT mockReturnValue implementations,
+    // so we explicitly reset getItem to return null (no cooldown stored).
+    vi.mocked(localStorage.getItem).mockReturnValue(null);
+    // Clear sessionStorage so session throttle passes.
+    sessionStorage.removeItem('upgrade_prompt_shown_after_download');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should show PostDownloadPrompt after first download for free user', async () => {
+    render(<PostDownloadPrompt isFreeUser={true} downloadCount={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('post-download-prompt')).toBeInTheDocument();
+    });
+  });
+
+  it('should NOT show PostDownloadPrompt for paid users', () => {
+    render(<PostDownloadPrompt isFreeUser={false} downloadCount={1} />);
+
+    expect(screen.queryByTestId('post-download-prompt')).not.toBeInTheDocument();
+  });
+
+  it('should NOT show PostDownloadPrompt when downloadCount is 0', () => {
+    render(<PostDownloadPrompt isFreeUser={true} downloadCount={0} />);
+
+    expect(screen.queryByTestId('post-download-prompt')).not.toBeInTheDocument();
+  });
+
+  it('should respect 72h localStorage cooldown', () => {
+    // localStorage is mocked as vi.fn() globally. We mock getItem to return
+    // a JSON with lastShown=now so canShowPrompt returns false (within cooldown).
+    const recentTimestamp = Date.now();
+    vi.mocked(localStorage.getItem).mockReturnValue(
+      JSON.stringify({ lastShown: recentTimestamp, weeklyCount: 1, weekStart: recentTimestamp })
+    );
+
+    render(<PostDownloadPrompt isFreeUser={true} downloadCount={1} />);
+
+    // Component should NOT render — canShowPrompt blocks it
+    expect(screen.queryByTestId('post-download-prompt')).not.toBeInTheDocument();
+  });
+
+  it('should fire upgrade_prompt_shown with trigger after_download', async () => {
+    render(<PostDownloadPrompt isFreeUser={true} downloadCount={1} />);
+
+    await waitFor(() => {
+      expect(mockAnalyticsTrack).toHaveBeenCalledWith('upgrade_prompt_shown', {
+        trigger: 'after_download',
+      });
+    });
+  });
+
+  it('should navigate to /dashboard/billing on CTA click', async () => {
+    render(<PostDownloadPrompt isFreeUser={true} downloadCount={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('post-download-prompt')).toBeInTheDocument();
+    });
+
+    const ctaLink = screen.getByTestId('post-download-prompt-cta');
+    expect(ctaLink).toHaveAttribute('href', '/dashboard/billing');
+  });
+});


### PR DESCRIPTION
## Summary

Implements PRD #10: UX & Conversion Optimization — Data-Driven Improvements

- **PostDownloadPrompt**: New inline upgrade nudge shown after first download for free users, with 72h localStorage cooldown + session throttle
- **Model Gallery badges**: Popular/Recommended badge pills on model cards + popularity-based sorting in gallery modal
- **BatchLimitModal & UpgradeSuccessBanner**: Fixed destination URL (`/pricing` → `/dashboard/billing`), updated button copy to "Unlock Batch Processing", added analytics tracking + 24h cooldown on UpgradeSuccessBanner
- **Cross-session frequency capping**: New `client/utils/promptFrequency.ts` utility preventing prompt fatigue across browser sessions

## Files Changed

### New Files
- `client/components/features/workspace/PostDownloadPrompt.tsx`
- `client/utils/promptFrequency.ts`
- `tests/unit/client/upgrade-prompts.unit.spec.tsx` (10 tests)

### Modified Files
- `client/components/features/workspace/Workspace.tsx` — downloadCount state + PostDownloadPrompt integration
- `client/components/features/workspace/UpgradeSuccessBanner.tsx` — analytics + 24h cooldown + fixed URL
- `client/components/features/workspace/BatchLimitModal.tsx` — fixed URL + button copy
- `client/components/features/workspace/ModelCard.tsx` — badge rendering
- `client/components/features/workspace/ModelGalleryModal.tsx` — popularity sorting
- `shared/types/coreflow.types.ts` — badge/popularity fields on quality tier config
- `server/analytics/types.ts` — upgrade_prompt_* event types
- `app/api/analytics/event/route.ts` — upgrade_prompt_* in ALLOWED_EVENTS
- `locales/en/workspace.json` — unlockBatchButton key
- `tests/unit/client/model-gallery-modal.unit.spec.tsx` — badge + sorting tests

## Test Plan
- [x] 10 new unit tests for PostDownloadPrompt, UpgradeSuccessBanner, BatchLimitModal
- [x] 4 new unit tests for ModelGalleryModal badges and sorting
- [x] `yarn verify` passes
- [x] 1995 unit tests pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)