### PR TITLE
feat: regional dynamic pricing system (PPP-adjusted)

### DIFF
--- a/app/[locale]/pricing/PricingPageClient.tsx
+++ b/app/[locale]/pricing/PricingPageClient.tsx
@@ -22,27 +22,6 @@ import { analytics } from '@client/analytics';
 import { useRegionTier } from '@client/hooks/useRegionTier';
 import { useSearchParams } from 'next/navigation';
 
-const SUBSCRIPTION_VALUE_COUNTRIES = new Set([
-  'US',
-  'CA',
-  'GB',
-  'IE',
-  'AU',
-  'NZ',
-  'DE',
-  'FR',
-  'NL',
-  'BE',
-  'CH',
-  'AT',
-  'SE',
-  'NO',
-  'DK',
-  'FI',
-]);
-
-const CREDIT_PACK_COUNTRIES = new Set(['PH', 'IN']);
-
 export default function PricingPageClient() {
   const t = useTranslations('pricing');
   const searchParams = useSearchParams();
@@ -55,13 +34,10 @@ export default function PricingPageClient() {
   const [cancelingSchedule, setCancelingSchedule] = useState(false);
   const [buttonLoadingStates, setButtonLoadingStates] = useState<Record<string, boolean>>({});
 
-  const { tier: regionTier, country: regionCountry } = useRegionTier();
+  const { discountPercent, pricingRegion } = useRegionTier();
 
-  const showCreditPackNote =
-    regionCountry !== null &&
-    (CREDIT_PACK_COUNTRIES.has(regionCountry) || regionTier === 'restricted');
-  const showSubscriptionNote =
-    regionCountry !== null && SUBSCRIPTION_VALUE_COUNTRIES.has(regionCountry);
+  const showCreditPackNote = discountPercent > 0;
+  const showSubscriptionNote = discountPercent > 0;
 
   // Track pricing_page_viewed event once on mount
   const hasTrackedPageView = useRef(false);
@@ -121,6 +97,8 @@ export default function PricingPageClient() {
       entryPoint,
       currentPlan,
       referrer: document.referrer || undefined,
+      pricingRegion: pricingRegion || 'standard',
+      discountPercent: discountPercent || 0,
     });
   }, [searchParams, profile?.subscription_tier, loading]);
 
@@ -359,6 +337,16 @@ export default function PricingPageClient() {
           <p className="text-lg text-text-secondary max-w-2xl mx-auto">{t('page.subtitle')}</p>
         </div>
 
+        {/* Regional Pricing Banner */}
+        {discountPercent > 0 && (
+          <div
+            className="bg-success/10 border border-success/20 rounded-lg p-4 mb-8 max-w-3xl mx-auto text-center"
+            data-testid="regional-pricing-banner"
+          >
+            <p className="text-sm text-success font-medium">Special pricing for your region</p>
+          </div>
+        )}
+
         {/* Credit Packs Section */}
         <div className="mb-16" data-testid="credit-packs-section">
           <div className="text-center mb-8">
@@ -372,7 +360,7 @@ export default function PricingPageClient() {
                 className="mt-4 text-sm text-success font-medium"
                 data-testid="geo-credit-pack-note"
               >
-                No subscription needed — buy only what you use
+                Regional pricing applied — credit packs adjusted for your region
               </p>
             )}
           </div>
@@ -382,6 +370,7 @@ export default function PricingPageClient() {
               onPurchaseStart={() => {}}
               onPurchaseComplete={() => window.location.reload()}
               onError={error => console.error(error)}
+              discountPercent={discountPercent}
             />
           </div>
 
@@ -470,7 +459,7 @@ export default function PricingPageClient() {
 
           {showSubscriptionNote && (
             <p className="text-center text-sm text-accent mb-6" data-testid="geo-subscription-note">
-              Most users in your region save 40% with a monthly plan vs. buying credits
+              Subscription plans adjusted for your region — get the best value with a monthly plan
             </p>
           )}
 
@@ -533,6 +522,7 @@ export default function PricingPageClient() {
                       }
                       currentSubscriptionPrice={currentSubscriptionPrice}
                       loading={buttonLoadingStates[starterPriceId] || false}
+                      discountPercent={discountPercent}
                     />
                   ) : null;
                 })()}
@@ -565,6 +555,7 @@ export default function PricingPageClient() {
                   }
                   currentSubscriptionPrice={currentSubscriptionPrice}
                   loading={buttonLoadingStates[STRIPE_PRICES.HOBBY_MONTHLY] || false}
+                  discountPercent={discountPercent}
                 />
 
                 <PricingCard
@@ -596,6 +587,7 @@ export default function PricingPageClient() {
                   }
                   currentSubscriptionPrice={currentSubscriptionPrice}
                   loading={buttonLoadingStates[STRIPE_PRICES.PRO_MONTHLY] || false}
+                  discountPercent={discountPercent}
                 />
 
                 <PricingCard
@@ -626,6 +618,7 @@ export default function PricingPageClient() {
                   }
                   currentSubscriptionPrice={currentSubscriptionPrice}
                   loading={buttonLoadingStates[STRIPE_PRICES.BUSINESS_MONTHLY] || false}
+                  discountPercent={discountPercent}
                 />
               </>
             )}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -5,6 +5,11 @@ import { trackServerEvent } from '@server/analytics';
 import { clientEnv, serverEnv } from '@shared/config/env';
 import { assertKnownPriceId, resolvePlanOrPack } from '@shared/config/stripe';
 import { getTrialConfig } from '@shared/config/subscription.config';
+import {
+  getPricingRegion,
+  getRegionalPriceId,
+  getDiscountedPriceInCents,
+} from '@shared/config/pricing-regions';
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
 
@@ -333,6 +338,41 @@ export async function POST(request: NextRequest) {
     // 6. Get or create Stripe customer
     const customerId = await getOrCreateCustomerId(user, token);
 
+    // 6.5. Detect country and resolve regional pricing
+    const country =
+      request.headers.get('CF-IPCountry') ||
+      request.headers.get('cf-ipcountry') ||
+      (serverEnv.ENV === 'test' ? request.headers.get('x-test-country') : null);
+    const pricingConfig = getPricingRegion(country || '');
+
+    // 6.6. Log region mismatch for monitoring (non-blocking, does not affect checkout)
+    if (country && !isTestMode) {
+      try {
+        const { data: profile } = await supabaseAdmin
+          .from('profiles')
+          .select('signup_country')
+          .eq('id', user.id)
+          .single();
+
+        if (profile?.signup_country && profile.signup_country !== country) {
+          const signupRegion = getPricingRegion(profile.signup_country);
+          await trackServerEvent(
+            'pricing_region_mismatch',
+            {
+              signupCountry: profile.signup_country,
+              signupRegion: signupRegion.region,
+              checkoutCountry: country,
+              checkoutRegion: pricingConfig.region,
+              discountPercent: pricingConfig.discountPercent,
+            },
+            { apiKey: serverEnv.AMPLITUDE_API_KEY, userId: user.id }
+          );
+        }
+      } catch {
+        // Mismatch logging is best-effort — never block checkout
+      }
+    }
+
     // 7. Verify price type matches expected (double-check with Stripe in production)
     if (!isTestMode && resolvedPrice) {
       const price = await stripe.prices.retrieve(validatedPriceId);
@@ -362,25 +402,65 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 7. Create Stripe Checkout Session (supports both subscription and payment modes)
+    // 8. Create Stripe Checkout Session (supports both subscription and payment modes)
     const baseUrl = request.headers.get('origin') || clientEnv.BASE_URL;
     const checkoutMode = resolvedPrice?.type === 'pack' ? 'payment' : 'subscription';
 
     // Use unified metadata format for consistent webhook processing
     const unifiedMetadata = resolvePlanOrPack(validatedPriceId);
 
-    const sessionParams: Stripe.Checkout.SessionCreateParams = {
-      customer: customerId,
-      line_items: [
+    // Resolve regional price for subscriptions
+    let checkoutPriceId = validatedPriceId;
+    if (resolvedPrice?.type === 'plan' && unifiedMetadata) {
+      checkoutPriceId = getRegionalPriceId(
+        validatedPriceId,
+        pricingConfig.region,
+        unifiedMetadata.key
+      );
+    }
+
+    // Build line_items based on purchase type and regional pricing
+    let lineItems: Stripe.Checkout.SessionCreateParams.LineItem[];
+    if (resolvedPrice?.type === 'pack' && pricingConfig.discountPercent > 0) {
+      // For discounted credit packs, use price_data with inline discounted amount
+      const originalPrice = await stripe.prices.retrieve(validatedPriceId);
+      const productId =
+        typeof originalPrice.product === 'string'
+          ? originalPrice.product
+          : originalPrice.product.id;
+
+      lineItems = [
         {
-          price: validatedPriceId,
+          price_data: {
+            currency: 'usd',
+            product: productId,
+            unit_amount: getDiscountedPriceInCents(
+              originalPrice.unit_amount!,
+              pricingConfig.discountPercent
+            ),
+          },
           quantity: 1,
         },
-      ],
+      ];
+    } else {
+      // For subscriptions (already using regional Price ID) or standard-priced credit packs
+      lineItems = [
+        {
+          price: checkoutPriceId,
+          quantity: 1,
+        },
+      ];
+    }
+
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
+      customer: customerId,
+      line_items: lineItems,
       mode: checkoutMode,
       ui_mode: uiMode,
       metadata: {
         user_id: user.id,
+        pricing_region: pricingConfig.region,
+        discount_percent: pricingConfig.discountPercent.toString(),
         ...(unifiedMetadata
           ? {
               type: unifiedMetadata.type,
@@ -446,11 +526,13 @@ export async function POST(request: NextRequest) {
     await trackServerEvent(
       'checkout_started',
       {
-        priceId: validatedPriceId,
+        priceId: checkoutPriceId,
         purchaseType,
         sessionId: session.id,
         plan: unifiedMetadata?.type === 'plan' ? unifiedMetadata.key : undefined,
         pack: unifiedMetadata?.type === 'pack' ? unifiedMetadata.key : undefined,
+        pricingRegion: pricingConfig.region,
+        discountPercent: pricingConfig.discountPercent,
       },
       { apiKey: serverEnv.AMPLITUDE_API_KEY, userId: user.id }
     );

--- a/app/api/geo/route.ts
+++ b/app/api/geo/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getRegionTier } from '@/lib/anti-freeloader/region-classifier';
+import { getPricingRegion } from '@shared/config/pricing-regions';
 import { serverEnv } from '@shared/config/env';
 
 export const dynamic = 'force-dynamic';
@@ -11,8 +12,20 @@ export async function GET(req: NextRequest) {
     (serverEnv.ENV === 'test' ? req.headers.get('x-test-country') : null);
 
   if (!country) {
-    return NextResponse.json({ country: null, tier: 'standard' });
+    return NextResponse.json({
+      country: null,
+      tier: 'standard',
+      pricingRegion: 'standard',
+      discountPercent: 0,
+    });
   }
 
-  return NextResponse.json({ country, tier: getRegionTier(country) });
+  const pricingConfig = getPricingRegion(country);
+
+  return NextResponse.json({
+    country,
+    tier: getRegionTier(country),
+    pricingRegion: pricingConfig.region,
+    discountPercent: pricingConfig.discountPercent,
+  });
 }

--- a/client/components/features/landing/Pricing.tsx
+++ b/client/components/features/landing/Pricing.tsx
@@ -6,16 +6,31 @@ import { Button } from '@client/components/ui/Button';
 import { useCheckoutStore } from '@client/store/checkoutStore';
 import { useModalStore } from '@client/store/modalStore';
 import { useToastStore } from '@client/store/toastStore';
+import { useRegionTier } from '@client/hooks/useRegionTier';
 import { useUserStore } from '@client/store/userStore';
 import { prepareAuthRedirect } from '@client/utils/authRedirectManager';
 import { clientEnv } from '@shared/config/env';
 import { HOMEPAGE_TIERS, isStripePricesConfigured } from '@shared/config/stripe';
 import { Check } from 'lucide-react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { AmbientBackground } from '../../landing/AmbientBackground';
 
+/** Calculate discounted price for a tier, rounding to 2 decimal places. */
+export function calculateDiscountedPrice(priceValue: number, discountPercent: number): number {
+  if (discountPercent <= 0 || priceValue === 0) return priceValue;
+  return Math.round(priceValue * (1 - discountPercent / 100) * 100) / 100;
+}
+
+/** Format a numeric price as a USD string (e.g., 17.15 -> "$17.15"). */
+function formatPrice(value: number): string {
+  if (value === 0) return '$0';
+  // Use Number to strip trailing zeros: 7.60 → "7.6", but keep "$7.60" via toFixed
+  const formatted = value.toFixed(2).replace(/\.?0+$/, '');
+  return `$${formatted}`;
+}
+
 // Generate Product structured data for SEO
-const generateProductJsonLd = (tier: (typeof HOMEPAGE_TIERS)[number]) => ({
+const generateProductJsonLd = (tier: (typeof HOMEPAGE_TIERS)[number], overridePrice?: number) => ({
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: `${clientEnv.APP_NAME} ${tier.name}`,
@@ -26,7 +41,7 @@ const generateProductJsonLd = (tier: (typeof HOMEPAGE_TIERS)[number]) => ({
   },
   offers: {
     '@type': 'Offer',
-    price: tier.priceValue,
+    price: overridePrice ?? tier.priceValue,
     priceCurrency: 'USD',
     availability: 'https://schema.org/InStock',
     priceValidUntil: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
@@ -41,6 +56,21 @@ export const Pricing: React.FC = () => {
   const { user } = useUserStore();
   const { isCheckoutModalOpen, activePriceId, openCheckoutModal, closeCheckoutModal } =
     useCheckoutStore();
+  const { discountPercent } = useRegionTier();
+
+  // Pre-compute regional prices for all homepage tiers
+  const regionalTiers = useMemo(
+    () =>
+      HOMEPAGE_TIERS.map(tier => {
+        const regionalPrice = calculateDiscountedPrice(tier.priceValue, discountPercent);
+        return {
+          ...tier,
+          displayPrice: formatPrice(regionalPrice),
+          displayPriceValue: regionalPrice,
+        };
+      }),
+    [discountPercent]
+  );
 
   const handlePricingClick = (tier: (typeof HOMEPAGE_TIERS)[number]) => {
     // Free tier - just open registration
@@ -93,9 +123,14 @@ export const Pricing: React.FC = () => {
     <section id="pricing" className="py-32 bg-main relative overflow-hidden">
       <AmbientBackground variant="section" />
       {/* Product structured data for SEO */}
-      {HOMEPAGE_TIERS.filter(tier => tier.priceValue > 0).map(tier => (
-        <JsonLd key={`jsonld-${tier.name}`} data={generateProductJsonLd(tier)} />
-      ))}
+      {regionalTiers
+        .filter(tier => tier.priceValue > 0)
+        .map(tier => (
+          <JsonLd
+            key={`jsonld-${tier.name}`}
+            data={generateProductJsonLd(tier, tier.displayPriceValue)}
+          />
+        ))}
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <div className="text-center mb-24">
@@ -111,7 +146,7 @@ export const Pricing: React.FC = () => {
         </div>
 
         <div className="grid grid-cols-1 gap-12 lg:grid-cols-3 items-center">
-          {HOMEPAGE_TIERS.map(tier => (
+          {regionalTiers.map(tier => (
             <div
               key={tier.name}
               className={`
@@ -136,7 +171,9 @@ export const Pricing: React.FC = () => {
               </div>
 
               <div className="mb-8 flex items-baseline gap-1">
-                <span className="text-5xl font-black text-white tracking-tight">{tier.price}</span>
+                <span className="text-5xl font-black text-white tracking-tight">
+                  {tier.displayPrice}
+                </span>
                 <span className="text-text-muted font-medium">{tier.period}</span>
               </div>
 

--- a/client/components/stripe/CreditPackSelector.tsx
+++ b/client/components/stripe/CreditPackSelector.tsx
@@ -10,11 +10,14 @@ interface ICreditPackSelectorProps {
   onPurchaseStart?: () => void;
   onPurchaseComplete?: () => void;
   onError?: (error: Error) => void;
+  /** Regional discount percentage (0-100). When > 0, displays adjusted prices. */
+  discountPercent?: number;
 }
 
 export function CreditPackSelector({
   onPurchaseStart,
   onPurchaseComplete,
+  discountPercent = 0,
 }: ICreditPackSelectorProps): JSX.Element {
   const [selectedPack, setSelectedPack] = useState<string | null>(null);
   const [selectedPriceId, setSelectedPriceId] = useState<string | null>(null);
@@ -40,15 +43,20 @@ export function CreditPackSelector({
     handleCheckoutClose();
   };
 
+  const applyDiscount = (cents: number): number => {
+    if (discountPercent <= 0) return cents;
+    return Math.round(cents * (1 - discountPercent / 100));
+  };
+
   const formatPrice = (cents: number) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD',
-    }).format(cents / 100);
+    }).format(applyDiscount(cents) / 100);
   };
 
   const getPricePerCredit = (pack: ICreditPack) => {
-    return (pack.priceInCents / pack.credits / 100).toFixed(3);
+    return (applyDiscount(pack.priceInCents) / pack.credits / 100).toFixed(3);
   };
 
   return (

--- a/client/components/stripe/PricingCard.tsx
+++ b/client/components/stripe/PricingCard.tsx
@@ -30,6 +30,8 @@ interface IPricingCardProps {
   currentSubscriptionPrice?: number | null;
   /** Whether the subscribe button is in loading state */
   loading?: boolean;
+  /** Regional discount percentage (0-100). When > 0, displays adjusted price. */
+  discountPercent?: number;
 }
 
 // --- Helper Functions (SRP: separate logic from rendering) ---
@@ -175,6 +177,7 @@ export function PricingCard({
   trial,
   currentSubscriptionPrice,
   loading = false,
+  discountPercent = 0,
 }: IPricingCardProps): JSX.Element {
   const {
     handleCheckout,
@@ -190,6 +193,10 @@ export function PricingCard({
     disabled,
   });
 
+  // Calculate regional display price (clean — user sees only their price)
+  const displayPrice =
+    discountPercent > 0 ? Math.round(price * (1 - discountPercent / 100) * 100) / 100 : price;
+
   const isCurrentPlan = disabled && !scheduled;
   const badge = getBadgeConfig(disabled, scheduled, recommended, disabledReason, trial);
   const buttonText = getButtonText(
@@ -202,7 +209,7 @@ export function PricingCard({
     trial,
     onSelect,
     currentSubscriptionPrice,
-    price
+    displayPrice
   );
 
   return (
@@ -225,9 +232,9 @@ export function PricingCard({
         )}
 
         <div className="text-center my-6">
-          <div className="text-4xl font-bold text-text-primary">
+          <div className="text-4xl font-bold text-text-primary" data-testid="pricing-card-price">
             {currency === 'USD' ? '$' : currency}
-            {price}
+            {displayPrice}
           </div>
           {interval && <div className="text-sm text-text-secondary mt-1">per {interval}</div>}
         </div>

--- a/client/hooks/useRegionTier.ts
+++ b/client/hooks/useRegionTier.ts
@@ -6,6 +6,8 @@ import type { RegionTier } from '@/lib/anti-freeloader/region-classifier';
 interface IGeoCache {
   tier: RegionTier;
   country: string | null;
+  pricingRegion: string;
+  discountPercent: number;
 }
 
 // Module-level cache — persists for the browser session
@@ -16,27 +18,61 @@ export function useRegionTier(): {
   country: string | null;
   isLoading: boolean;
   isRestricted: boolean;
+  pricingRegion: string;
+  discountPercent: number;
 } {
   const [tier, setTier] = useState<RegionTier | null>(cachedGeo?.tier ?? null);
   const [country, setCountry] = useState<string | null>(cachedGeo?.country ?? null);
+  const [pricingRegion, setPricingRegion] = useState<string>(
+    cachedGeo?.pricingRegion ?? 'standard'
+  );
+  const [discountPercent, setDiscountPercent] = useState<number>(cachedGeo?.discountPercent ?? 0);
   const [isLoading, setIsLoading] = useState(cachedGeo === null);
 
   useEffect(() => {
     if (cachedGeo !== null) return;
     fetch('/api/geo')
       .then(r => r.json())
-      .then((data: { tier?: RegionTier; country?: string | null }) => {
-        cachedGeo = { tier: data.tier ?? 'standard', country: data.country ?? null };
-        setTier(cachedGeo.tier);
-        setCountry(cachedGeo.country);
-      })
+      .then(
+        (data: {
+          tier?: RegionTier;
+          country?: string | null;
+          pricingRegion?: string;
+          discountPercent?: number;
+        }) => {
+          cachedGeo = {
+            tier: data.tier ?? 'standard',
+            country: data.country ?? null,
+            pricingRegion: data.pricingRegion ?? 'standard',
+            discountPercent: data.discountPercent ?? 0,
+          };
+          setTier(cachedGeo.tier);
+          setCountry(cachedGeo.country);
+          setPricingRegion(cachedGeo.pricingRegion);
+          setDiscountPercent(cachedGeo.discountPercent);
+        }
+      )
       .catch(() => {
-        cachedGeo = { tier: 'standard', country: null }; // safe default on network failure
+        cachedGeo = {
+          tier: 'standard',
+          country: null,
+          pricingRegion: 'standard',
+          discountPercent: 0,
+        };
         setTier('standard');
         setCountry(null);
+        setPricingRegion('standard');
+        setDiscountPercent(0);
       })
       .finally(() => setIsLoading(false));
   }, []);
 
-  return { tier, country, isLoading, isRestricted: tier === 'restricted' };
+  return {
+    tier,
+    country,
+    isLoading,
+    isRestricted: tier === 'restricted',
+    pricingRegion,
+    discountPercent,
+  };
 }

--- a/lib/anti-freeloader/region-classifier.ts
+++ b/lib/anti-freeloader/region-classifier.ts
@@ -1,3 +1,7 @@
+// Re-export pricing region utilities for colocation with geo classification
+export { getPricingRegion, getDiscountPercent } from '@shared/config/pricing-regions';
+export type { PricingRegion, IPricingRegionConfig } from '@shared/config/pricing-regions';
+
 export type RegionTier = 'standard' | 'restricted';
 
 /**

--- a/server/analytics/index.ts
+++ b/server/analytics/index.ts
@@ -18,4 +18,5 @@ export type {
   ISubscriptionProperties,
   ICreditPackProperties,
   IImageUpscaledProperties,
+  ICheckoutStartedProperties,
 } from '@server/analytics/types';

--- a/server/analytics/types.ts
+++ b/server/analytics/types.ts
@@ -62,6 +62,8 @@ export interface IPricingPageViewedProperties {
   entryPoint: 'navbar' | 'batch_limit_modal' | 'out_of_credits_modal' | 'pseo_cta' | 'direct';
   currentPlan: 'free' | 'starter' | 'hobby' | 'pro' | 'business';
   referrer?: string;
+  pricingRegion?: string;
+  discountPercent?: number;
 }
 
 export interface ICheckoutAbandonedProperties {
@@ -69,6 +71,24 @@ export interface ICheckoutAbandonedProperties {
   step: 'plan_selection' | 'stripe_embed';
   timeSpentMs: number;
   plan: 'free' | 'starter' | 'hobby' | 'pro' | 'business';
+  pricingRegion?: string;
+}
+
+export interface ICheckoutStartedProperties {
+  priceId: string;
+  purchaseType: string;
+  sessionId: string;
+  plan?: string;
+  pack?: string;
+  pricingRegion?: string;
+  discountPercent?: number;
+}
+
+export interface ICheckoutCompletedProperties {
+  priceId: string;
+  purchaseType: string;
+  sessionId: string;
+  pricingRegion?: string;
 }
 
 export type IUpgradePromptTrigger =
@@ -232,6 +252,8 @@ export type IAnalyticsEventName =
   | 'pseo_scroll_depth'
   | 'pseo_faq_expanded'
   | 'pseo_internal_link_clicked'
+  // Regional pricing monitoring events (server-side only)
+  | 'pricing_region_mismatch'
   // Amplitude identity events (server-side only)
   | '$identify';
 

--- a/shared/config/env.ts
+++ b/shared/config/env.ts
@@ -299,6 +299,36 @@ const serverEnvSchema = z.object({
   MODEL_VERSION_REALESRGAN_ANIME: z.string().optional(),
   MODEL_VERSION_P_IMAGE_EDIT: z.string().optional(),
   MODEL_VERSION_FLUX_KONTEXT_FAST: z.string().optional(),
+
+  // ==========================================
+  // REGIONAL PRICING (Stripe Price IDs)
+  // Leave empty to fallback to standard price
+  // ==========================================
+  // South Asia (65% off)
+  STRIPE_PRICE_STARTER_SOUTH_ASIA: z.string().default(''),
+  STRIPE_PRICE_HOBBY_SOUTH_ASIA: z.string().default(''),
+  STRIPE_PRICE_PRO_SOUTH_ASIA: z.string().default(''),
+  STRIPE_PRICE_BUSINESS_SOUTH_ASIA: z.string().default(''),
+  // Southeast Asia (60% off)
+  STRIPE_PRICE_STARTER_SOUTHEAST_ASIA: z.string().default(''),
+  STRIPE_PRICE_HOBBY_SOUTHEAST_ASIA: z.string().default(''),
+  STRIPE_PRICE_PRO_SOUTHEAST_ASIA: z.string().default(''),
+  STRIPE_PRICE_BUSINESS_SOUTHEAST_ASIA: z.string().default(''),
+  // LatAm (50% off)
+  STRIPE_PRICE_STARTER_LATAM: z.string().default(''),
+  STRIPE_PRICE_HOBBY_LATAM: z.string().default(''),
+  STRIPE_PRICE_PRO_LATAM: z.string().default(''),
+  STRIPE_PRICE_BUSINESS_LATAM: z.string().default(''),
+  // Eastern Europe (40% off)
+  STRIPE_PRICE_STARTER_EASTERN_EUROPE: z.string().default(''),
+  STRIPE_PRICE_HOBBY_EASTERN_EUROPE: z.string().default(''),
+  STRIPE_PRICE_PRO_EASTERN_EUROPE: z.string().default(''),
+  STRIPE_PRICE_BUSINESS_EASTERN_EUROPE: z.string().default(''),
+  // Africa (65% off)
+  STRIPE_PRICE_STARTER_AFRICA: z.string().default(''),
+  STRIPE_PRICE_HOBBY_AFRICA: z.string().default(''),
+  STRIPE_PRICE_PRO_AFRICA: z.string().default(''),
+  STRIPE_PRICE_BUSINESS_AFRICA: z.string().default(''),
 });
 
 export type IServerEnv = z.infer<typeof serverEnvSchema>;
@@ -410,6 +440,28 @@ function loadServerEnv(): IServerEnv {
     MODEL_VERSION_REALESRGAN_ANIME: process.env.MODEL_VERSION_REALESRGAN_ANIME,
     MODEL_VERSION_P_IMAGE_EDIT: process.env.MODEL_VERSION_P_IMAGE_EDIT,
     MODEL_VERSION_FLUX_KONTEXT_FAST: process.env.MODEL_VERSION_FLUX_KONTEXT_FAST,
+
+    // Regional Pricing
+    STRIPE_PRICE_STARTER_SOUTH_ASIA: process.env.STRIPE_PRICE_STARTER_SOUTH_ASIA || '',
+    STRIPE_PRICE_HOBBY_SOUTH_ASIA: process.env.STRIPE_PRICE_HOBBY_SOUTH_ASIA || '',
+    STRIPE_PRICE_PRO_SOUTH_ASIA: process.env.STRIPE_PRICE_PRO_SOUTH_ASIA || '',
+    STRIPE_PRICE_BUSINESS_SOUTH_ASIA: process.env.STRIPE_PRICE_BUSINESS_SOUTH_ASIA || '',
+    STRIPE_PRICE_STARTER_SOUTHEAST_ASIA: process.env.STRIPE_PRICE_STARTER_SOUTHEAST_ASIA || '',
+    STRIPE_PRICE_HOBBY_SOUTHEAST_ASIA: process.env.STRIPE_PRICE_HOBBY_SOUTHEAST_ASIA || '',
+    STRIPE_PRICE_PRO_SOUTHEAST_ASIA: process.env.STRIPE_PRICE_PRO_SOUTHEAST_ASIA || '',
+    STRIPE_PRICE_BUSINESS_SOUTHEAST_ASIA: process.env.STRIPE_PRICE_BUSINESS_SOUTHEAST_ASIA || '',
+    STRIPE_PRICE_STARTER_LATAM: process.env.STRIPE_PRICE_STARTER_LATAM || '',
+    STRIPE_PRICE_HOBBY_LATAM: process.env.STRIPE_PRICE_HOBBY_LATAM || '',
+    STRIPE_PRICE_PRO_LATAM: process.env.STRIPE_PRICE_PRO_LATAM || '',
+    STRIPE_PRICE_BUSINESS_LATAM: process.env.STRIPE_PRICE_BUSINESS_LATAM || '',
+    STRIPE_PRICE_STARTER_EASTERN_EUROPE: process.env.STRIPE_PRICE_STARTER_EASTERN_EUROPE || '',
+    STRIPE_PRICE_HOBBY_EASTERN_EUROPE: process.env.STRIPE_PRICE_HOBBY_EASTERN_EUROPE || '',
+    STRIPE_PRICE_PRO_EASTERN_EUROPE: process.env.STRIPE_PRICE_PRO_EASTERN_EUROPE || '',
+    STRIPE_PRICE_BUSINESS_EASTERN_EUROPE: process.env.STRIPE_PRICE_BUSINESS_EASTERN_EUROPE || '',
+    STRIPE_PRICE_STARTER_AFRICA: process.env.STRIPE_PRICE_STARTER_AFRICA || '',
+    STRIPE_PRICE_HOBBY_AFRICA: process.env.STRIPE_PRICE_HOBBY_AFRICA || '',
+    STRIPE_PRICE_PRO_AFRICA: process.env.STRIPE_PRICE_PRO_AFRICA || '',
+    STRIPE_PRICE_BUSINESS_AFRICA: process.env.STRIPE_PRICE_BUSINESS_AFRICA || '',
   };
 
   return serverEnvSchema.parse(env);

--- a/shared/config/pricing-regions.ts
+++ b/shared/config/pricing-regions.ts
@@ -1,0 +1,143 @@
+/**
+ * Regional Dynamic Pricing Configuration
+ *
+ * Maps countries to pricing regions with discount percentages.
+ * Used by checkout and pricing display to show PPP-adjusted prices.
+ *
+ * Abuse model:
+ * - CF-IPCountry is Cloudflare-edge-set, not spoofable by client
+ * - VPN users get the VPN exit node's country (acceptable tradeoff)
+ * - Fingerprint system already catches multi-account fraud
+ * - Stripe's billing address is an additional signal but not enforced
+ */
+
+import { serverEnv } from './env';
+
+export type PricingRegion =
+  | 'standard'
+  | 'south_asia'
+  | 'southeast_asia'
+  | 'latam'
+  | 'eastern_europe'
+  | 'africa';
+
+export interface IPricingRegionConfig {
+  region: PricingRegion;
+  discountPercent: number;
+  countries: readonly string[];
+}
+
+const PRICING_REGION_CONFIGS: readonly IPricingRegionConfig[] = [
+  {
+    region: 'south_asia',
+    discountPercent: 65,
+    countries: ['IN', 'PK', 'BD', 'LK', 'NP'],
+  },
+  {
+    region: 'southeast_asia',
+    discountPercent: 60,
+    countries: ['PH', 'ID', 'VN', 'TH', 'MM', 'KH', 'LA'],
+  },
+  {
+    region: 'latam',
+    discountPercent: 50,
+    countries: ['BR', 'MX', 'CO', 'AR', 'PE', 'CL', 'EC', 'VE', 'BO', 'PY', 'UY'],
+  },
+  {
+    region: 'eastern_europe',
+    discountPercent: 40,
+    countries: ['UA', 'RO', 'BG', 'RS', 'HR', 'BA', 'MK', 'AL', 'MD', 'GE'],
+  },
+  {
+    region: 'africa',
+    discountPercent: 65,
+    countries: ['NG', 'KE', 'ZA', 'GH', 'ET', 'TZ', 'UG', 'RW', 'SN', 'CI'],
+  },
+] as const;
+
+const STANDARD_CONFIG: IPricingRegionConfig = {
+  region: 'standard',
+  discountPercent: 0,
+  countries: [],
+};
+
+// Build a country-to-config lookup map for O(1) access
+const countryToRegionMap = new Map<string, IPricingRegionConfig>();
+for (const config of PRICING_REGION_CONFIGS) {
+  for (const country of config.countries) {
+    countryToRegionMap.set(country, config);
+  }
+}
+
+/**
+ * Get the pricing region config for a country code.
+ * Returns standard (0% discount) for unknown/unmapped countries.
+ */
+export function getPricingRegion(countryCode: string): IPricingRegionConfig {
+  if (!countryCode) return STANDARD_CONFIG;
+  return countryToRegionMap.get(countryCode.toUpperCase()) ?? STANDARD_CONFIG;
+}
+
+/**
+ * Get just the discount percentage for a country code.
+ */
+export function getDiscountPercent(countryCode: string): number {
+  return getPricingRegion(countryCode).discountPercent;
+}
+
+/**
+ * Calculate the discounted price in cents, rounded to nearest cent.
+ */
+export function getDiscountedPriceInCents(
+  basePriceInCents: number,
+  discountPercent: number
+): number {
+  if (discountPercent <= 0) return basePriceInCents;
+  return Math.round(basePriceInCents * (1 - discountPercent / 100));
+}
+
+/**
+ * Plan keys used in env var naming for regional prices
+ */
+const PLAN_KEY_TO_ENV_SUFFIX: Record<string, string> = {
+  starter: 'STARTER',
+  hobby: 'HOBBY',
+  pro: 'PRO',
+  business: 'BUSINESS',
+};
+
+/**
+ * Region to env var suffix mapping
+ */
+const REGION_TO_ENV_SUFFIX: Partial<Record<PricingRegion, string>> = {
+  south_asia: 'SOUTH_ASIA',
+  southeast_asia: 'SOUTHEAST_ASIA',
+  latam: 'LATAM',
+  eastern_europe: 'EASTERN_EUROPE',
+  africa: 'AFRICA',
+};
+
+/**
+ * Resolve a regional Stripe Price ID for subscriptions.
+ * Looks up the env var `STRIPE_PRICE_{PLAN}_{REGION}`.
+ * Falls back to basePriceId if no regional price is configured.
+ */
+export function getRegionalPriceId(
+  basePriceId: string,
+  region: PricingRegion,
+  planKey: string
+): string {
+  if (region === 'standard') return basePriceId;
+
+  const planSuffix = PLAN_KEY_TO_ENV_SUFFIX[planKey];
+  const regionSuffix = REGION_TO_ENV_SUFFIX[region];
+  if (!planSuffix || !regionSuffix) return basePriceId;
+
+  const envKey = `STRIPE_PRICE_${planSuffix}_${regionSuffix}` as keyof typeof serverEnv;
+  const regionalPriceId = serverEnv[envKey] as string | undefined;
+
+  // Graceful degradation: empty or missing env var falls back to base price
+  return regionalPriceId && regionalPriceId.startsWith('price_') ? regionalPriceId : basePriceId;
+}
+
+export { PRICING_REGION_CONFIGS };

--- a/tests/unit/pricing/anti-abuse.unit.spec.ts
+++ b/tests/unit/pricing/anti-abuse.unit.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { getPricingRegion, getDiscountPercent } from '@shared/config/pricing-regions';
+
+/**
+ * Anti-Abuse & Edge Case Tests for Regional Dynamic Pricing (Phase 5)
+ *
+ * Validates:
+ * - Discount is applied based on CF-IPCountry (per-request), not signup_country
+ * - Standard regions get 0% discount
+ * - Missing/empty CF-IPCountry defaults to standard (graceful degradation)
+ * - Tor exit nodes (T1) are treated as standard
+ * - Unknown country codes are treated as standard
+ * - Pricing is stateless — two calls with different countries return different regions
+ */
+describe('Anti-Abuse & Edge Cases', () => {
+  describe('should apply discount based on CF-IPCountry not signup_country', () => {
+    it('returns 65% discount for IN regardless of any prior signup country', () => {
+      // The pricing function only takes a country code — it has no concept of signup_country.
+      // This is by design: CF-IPCountry at checkout time determines the discount.
+      const config = getPricingRegion('IN');
+      expect(config.region).toBe('south_asia');
+      expect(config.discountPercent).toBe(65);
+    });
+
+    it('returns 60% discount for PH regardless of any prior signup country', () => {
+      const config = getPricingRegion('PH');
+      expect(config.region).toBe('southeast_asia');
+      expect(config.discountPercent).toBe(60);
+    });
+
+    it('returns 50% discount for BR regardless of any prior signup country', () => {
+      const config = getPricingRegion('BR');
+      expect(config.region).toBe('latam');
+      expect(config.discountPercent).toBe(50);
+    });
+
+    it('returns 40% discount for UA regardless of any prior signup country', () => {
+      const config = getPricingRegion('UA');
+      expect(config.region).toBe('eastern_europe');
+      expect(config.discountPercent).toBe(40);
+    });
+
+    it('returns 65% discount for NG regardless of any prior signup country', () => {
+      const config = getPricingRegion('NG');
+      expect(config.region).toBe('africa');
+      expect(config.discountPercent).toBe(65);
+    });
+  });
+
+  describe('should not apply discount when CF-IPCountry is standard', () => {
+    it('returns 0% discount for US', () => {
+      const config = getPricingRegion('US');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns 0% discount for GB', () => {
+      const config = getPricingRegion('GB');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns 0% discount for DE', () => {
+      const config = getPricingRegion('DE');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns 0% discount for JP', () => {
+      const config = getPricingRegion('JP');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns 0% via getDiscountPercent helper for standard countries', () => {
+      expect(getDiscountPercent('US')).toBe(0);
+      expect(getDiscountPercent('GB')).toBe(0);
+      expect(getDiscountPercent('DE')).toBe(0);
+    });
+  });
+
+  describe('should handle missing CF-IPCountry gracefully (standard)', () => {
+    it('returns standard for empty string', () => {
+      const config = getPricingRegion('');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns 0% discount via getDiscountPercent for empty string', () => {
+      expect(getDiscountPercent('')).toBe(0);
+    });
+
+    it('checkout route passes empty string to getPricingRegion when country is null', () => {
+      // In the checkout route: getPricingRegion(country || '')
+      // This test verifies that getPricingRegion('') returns standard safely
+      const countryFromHeader: string | null = null;
+      const config = getPricingRegion(countryFromHeader || '');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('checkout route passes empty string to getPricingRegion when country is undefined', () => {
+      const countryFromHeader: string | undefined = undefined;
+      const config = getPricingRegion(countryFromHeader || '');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+  });
+
+  describe('should handle Tor exit nodes as standard', () => {
+    it('returns standard for T1 (Cloudflare Tor identifier)', () => {
+      const config = getPricingRegion('T1');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns 0% discount via getDiscountPercent for T1', () => {
+      expect(getDiscountPercent('T1')).toBe(0);
+    });
+  });
+
+  describe('should handle unknown country codes as standard', () => {
+    it('returns standard for XX', () => {
+      const config = getPricingRegion('XX');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns standard for ZZ', () => {
+      const config = getPricingRegion('ZZ');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns standard for A1 (Cloudflare anonymous proxy)', () => {
+      const config = getPricingRegion('A1');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('returns standard for random invalid codes', () => {
+      expect(getPricingRegion('QQ').region).toBe('standard');
+      expect(getPricingRegion('99').region).toBe('standard');
+      expect(getPricingRegion('INVALID').region).toBe('standard');
+    });
+  });
+
+  describe('should apply discount per-request, not per-user (statelessness)', () => {
+    it('two consecutive calls with different countries return different regions', () => {
+      // First request from India
+      const india = getPricingRegion('IN');
+      expect(india.region).toBe('south_asia');
+      expect(india.discountPercent).toBe(65);
+
+      // Second request from US (same "user", different country)
+      const us = getPricingRegion('US');
+      expect(us.region).toBe('standard');
+      expect(us.discountPercent).toBe(0);
+
+      // Third request from Brazil
+      const brazil = getPricingRegion('BR');
+      expect(brazil.region).toBe('latam');
+      expect(brazil.discountPercent).toBe(50);
+
+      // Verify they are independent — no state carried over
+      expect(india.region).not.toBe(us.region);
+      expect(us.discountPercent).not.toBe(brazil.discountPercent);
+    });
+
+    it('same country code always returns the same result (pure function)', () => {
+      const first = getPricingRegion('PH');
+      const second = getPricingRegion('PH');
+      expect(first.region).toBe(second.region);
+      expect(first.discountPercent).toBe(second.discountPercent);
+    });
+
+    it('function is deterministic across all regions', () => {
+      const countries = ['IN', 'PH', 'BR', 'UA', 'NG', 'US', 'XX', '', 'T1'];
+      const firstPass = countries.map(c => getPricingRegion(c));
+      const secondPass = countries.map(c => getPricingRegion(c));
+
+      for (let i = 0; i < countries.length; i++) {
+        expect(firstPass[i].region).toBe(secondPass[i].region);
+        expect(firstPass[i].discountPercent).toBe(secondPass[i].discountPercent);
+      }
+    });
+  });
+});

--- a/tests/unit/pricing/checkout-regional.unit.spec.ts
+++ b/tests/unit/pricing/checkout-regional.unit.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for Phase 2: Regional Price Routing in Checkout
+ *
+ * Validates:
+ * - getRegionalPriceId resolves regional Stripe Price IDs from env vars
+ * - getRegionalPriceId falls back to base price when regional not configured
+ * - getRegionalPriceId returns original price for standard region
+ * - getDiscountedPriceInCents calculates credit pack discounts correctly
+ * - Checkout session metadata includes pricing_region and discount_percent
+ */
+
+// Mock serverEnv to control regional price ID resolution
+const mockServerEnv: Record<string, string> = {
+  ENV: 'test',
+  STRIPE_PRICE_STARTER_SOUTH_ASIA: 'price_regional_starter_south_asia',
+  STRIPE_PRICE_HOBBY_SOUTH_ASIA: 'price_regional_hobby_south_asia',
+  STRIPE_PRICE_PRO_SOUTH_ASIA: '',
+  STRIPE_PRICE_BUSINESS_SOUTH_ASIA: '',
+  STRIPE_PRICE_STARTER_SOUTHEAST_ASIA: '',
+  STRIPE_PRICE_HOBBY_SOUTHEAST_ASIA: '',
+  STRIPE_PRICE_PRO_SOUTHEAST_ASIA: '',
+  STRIPE_PRICE_BUSINESS_SOUTHEAST_ASIA: '',
+  STRIPE_PRICE_STARTER_LATAM: '',
+  STRIPE_PRICE_HOBBY_LATAM: '',
+  STRIPE_PRICE_PRO_LATAM: '',
+  STRIPE_PRICE_BUSINESS_LATAM: '',
+  STRIPE_PRICE_STARTER_EASTERN_EUROPE: '',
+  STRIPE_PRICE_HOBBY_EASTERN_EUROPE: '',
+  STRIPE_PRICE_PRO_EASTERN_EUROPE: '',
+  STRIPE_PRICE_BUSINESS_EASTERN_EUROPE: '',
+  STRIPE_PRICE_STARTER_AFRICA: 'price_regional_starter_africa',
+  STRIPE_PRICE_HOBBY_AFRICA: '',
+  STRIPE_PRICE_PRO_AFRICA: '',
+  STRIPE_PRICE_BUSINESS_AFRICA: '',
+};
+
+vi.mock('@shared/config/env', () => ({
+  serverEnv: new Proxy({} as Record<string, string>, {
+    get(_, prop) {
+      return mockServerEnv[prop as string] ?? '';
+    },
+  }),
+  clientEnv: {
+    BASE_URL: 'http://localhost:3000',
+  },
+}));
+
+describe('Checkout Regional Pricing', () => {
+  // Import after mocking
+  let getRegionalPriceId: typeof import('@shared/config/pricing-regions').getRegionalPriceId;
+  let getDiscountedPriceInCents: typeof import('@shared/config/pricing-regions').getDiscountedPriceInCents;
+  let getPricingRegion: typeof import('@shared/config/pricing-regions').getPricingRegion;
+
+  beforeEach(async () => {
+    const mod = await import('@shared/config/pricing-regions');
+    getRegionalPriceId = mod.getRegionalPriceId;
+    getDiscountedPriceInCents = mod.getDiscountedPriceInCents;
+    getPricingRegion = mod.getPricingRegion;
+  });
+
+  describe('getRegionalPriceId', () => {
+    it('should return regional Price ID for south_asia starter when env var is set', () => {
+      const basePriceId = 'price_1Sz0fNL1vUl00LlZX1XClz95';
+      const result = getRegionalPriceId(basePriceId, 'south_asia', 'starter');
+      expect(result).toBe('price_regional_starter_south_asia');
+    });
+
+    it('should return regional Price ID for south_asia hobby when env var is set', () => {
+      const basePriceId = 'price_1Sz0fNL1vUl00LlZT6MMTxAg';
+      const result = getRegionalPriceId(basePriceId, 'south_asia', 'hobby');
+      expect(result).toBe('price_regional_hobby_south_asia');
+    });
+
+    it('should return regional Price ID for africa starter when env var is set', () => {
+      const basePriceId = 'price_1Sz0fNL1vUl00LlZX1XClz95';
+      const result = getRegionalPriceId(basePriceId, 'africa', 'starter');
+      expect(result).toBe('price_regional_starter_africa');
+    });
+
+    it('should fall back to base Price ID when regional env var is empty', () => {
+      const basePriceId = 'price_1Sz0fOL1vUl00LlZ7bbM2cDs';
+      const result = getRegionalPriceId(basePriceId, 'south_asia', 'pro');
+      expect(result).toBe(basePriceId);
+    });
+
+    it('should fall back to base Price ID when regional not configured for region', () => {
+      const basePriceId = 'price_1Sz0fNL1vUl00LlZX1XClz95';
+      const result = getRegionalPriceId(basePriceId, 'latam', 'starter');
+      expect(result).toBe(basePriceId);
+    });
+
+    it('should return original priceId for standard region', () => {
+      const basePriceId = 'price_1Sz0fNL1vUl00LlZX1XClz95';
+      const result = getRegionalPriceId(basePriceId, 'standard', 'starter');
+      expect(result).toBe(basePriceId);
+    });
+
+    it('should return base price for unknown plan key', () => {
+      const basePriceId = 'price_1Sz0fNL1vUl00LlZX1XClz95';
+      const result = getRegionalPriceId(basePriceId, 'south_asia', 'unknown_plan');
+      expect(result).toBe(basePriceId);
+    });
+  });
+
+  describe('getDiscountedPriceInCents for credit packs', () => {
+    it('should calculate credit pack small (499 cents) at 65% off as 175 cents', () => {
+      // 499 * (1 - 0.65) = 499 * 0.35 = 174.65 → rounds to 175
+      expect(getDiscountedPriceInCents(499, 65)).toBe(175);
+    });
+
+    it('should calculate credit pack medium (1499 cents) at 60% off', () => {
+      // 1499 * 0.40 = 599.6 → rounds to 600
+      expect(getDiscountedPriceInCents(1499, 60)).toBe(600);
+    });
+
+    it('should calculate credit pack large (2999 cents) at 50% off', () => {
+      // 2999 * 0.50 = 1499.5 → rounds to 1500
+      expect(getDiscountedPriceInCents(2999, 50)).toBe(1500);
+    });
+
+    it('should return full price for 0% discount', () => {
+      expect(getDiscountedPriceInCents(499, 0)).toBe(499);
+    });
+
+    it('should return full price for negative discount', () => {
+      expect(getDiscountedPriceInCents(499, -5)).toBe(499);
+    });
+  });
+
+  describe('Checkout metadata includes pricing_region', () => {
+    it('should resolve south_asia pricing config for India (IN)', () => {
+      const config = getPricingRegion('IN');
+      expect(config.region).toBe('south_asia');
+      expect(config.discountPercent).toBe(65);
+    });
+
+    it('should resolve standard pricing config for US', () => {
+      const config = getPricingRegion('US');
+      expect(config.region).toBe('standard');
+      expect(config.discountPercent).toBe(0);
+    });
+
+    it('pricing_region metadata value should be a valid region string', () => {
+      const validRegions = [
+        'standard',
+        'south_asia',
+        'southeast_asia',
+        'latam',
+        'eastern_europe',
+        'africa',
+      ];
+
+      // Test that all regions from getPricingRegion are valid metadata values
+      const testCountries = ['US', 'IN', 'PH', 'BR', 'UA', 'NG', 'XX', ''];
+      for (const country of testCountries) {
+        const config = getPricingRegion(country);
+        expect(validRegions).toContain(config.region);
+        // discount_percent should be stringifiable for Stripe metadata
+        expect(typeof config.discountPercent).toBe('number');
+        expect(config.discountPercent.toString()).toMatch(/^\d+$/);
+      }
+    });
+
+    it('subscription session metadata should include pricing_region and discount_percent fields', () => {
+      // Simulate building metadata the same way as checkout route
+      const pricingConfig = getPricingRegion('IN');
+      const metadata = {
+        user_id: 'test-user-123',
+        pricing_region: pricingConfig.region,
+        discount_percent: pricingConfig.discountPercent.toString(),
+        type: 'plan',
+        plan_key: 'starter',
+      };
+
+      expect(metadata).toHaveProperty('pricing_region', 'south_asia');
+      expect(metadata).toHaveProperty('discount_percent', '65');
+    });
+
+    it('credit pack session metadata should include pricing_region for discounted regions', () => {
+      const pricingConfig = getPricingRegion('PH');
+      const metadata = {
+        user_id: 'test-user-456',
+        pricing_region: pricingConfig.region,
+        discount_percent: pricingConfig.discountPercent.toString(),
+        type: 'pack',
+        pack_key: 'small',
+      };
+
+      expect(metadata).toHaveProperty('pricing_region', 'southeast_asia');
+      expect(metadata).toHaveProperty('discount_percent', '60');
+    });
+
+    it('standard region session metadata should include pricing_region as standard', () => {
+      const pricingConfig = getPricingRegion('US');
+      const metadata = {
+        user_id: 'test-user-789',
+        pricing_region: pricingConfig.region,
+        discount_percent: pricingConfig.discountPercent.toString(),
+        type: 'plan',
+        plan_key: 'pro',
+      };
+
+      expect(metadata).toHaveProperty('pricing_region', 'standard');
+      expect(metadata).toHaveProperty('discount_percent', '0');
+    });
+  });
+});

--- a/tests/unit/pricing/homepage-pricing.unit.spec.ts
+++ b/tests/unit/pricing/homepage-pricing.unit.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for Phase 4: Homepage Pricing with Regional Discounts
+ *
+ * Validates the calculateDiscountedPrice function used by the homepage
+ * Pricing component to display PPP-adjusted prices.
+ * Tests pure math — no React rendering required.
+ */
+
+// Mirror the exported function from Pricing.tsx
+function calculateDiscountedPrice(priceValue: number, discountPercent: number): number {
+  if (discountPercent <= 0 || priceValue === 0) return priceValue;
+  return Math.round(priceValue * (1 - discountPercent / 100) * 100) / 100;
+}
+
+describe('Homepage Pricing — Regional Discounts', () => {
+  describe('Discounted price calculation for homepage tiers', () => {
+    it('should calculate $49 at 65% off = $17.15', () => {
+      expect(calculateDiscountedPrice(49, 65)).toBe(17.15);
+    });
+
+    it('should calculate $19 at 60% off = $7.60', () => {
+      expect(calculateDiscountedPrice(19, 60)).toBe(7.6);
+    });
+
+    it('should keep $0 (free tier) at $0 regardless of discount', () => {
+      expect(calculateDiscountedPrice(0, 65)).toBe(0);
+      expect(calculateDiscountedPrice(0, 100)).toBe(0);
+      expect(calculateDiscountedPrice(0, 0)).toBe(0);
+    });
+
+    it('should keep $9 unchanged at 0% discount', () => {
+      expect(calculateDiscountedPrice(9, 0)).toBe(9);
+    });
+  });
+
+  describe('Additional homepage tier scenarios', () => {
+    it('should calculate $9 at 65% off = $3.15 (south_asia)', () => {
+      expect(calculateDiscountedPrice(9, 65)).toBe(3.15);
+    });
+
+    it('should calculate $9 at 60% off = $3.60 (southeast_asia)', () => {
+      expect(calculateDiscountedPrice(9, 60)).toBe(3.6);
+    });
+
+    it('should calculate $9 at 50% off = $4.50 (latam)', () => {
+      expect(calculateDiscountedPrice(9, 50)).toBe(4.5);
+    });
+
+    it('should calculate $9 at 40% off = $5.40 (eastern_europe)', () => {
+      expect(calculateDiscountedPrice(9, 40)).toBe(5.4);
+    });
+
+    it('should calculate $49 at 50% off = $24.50', () => {
+      expect(calculateDiscountedPrice(49, 50)).toBe(24.5);
+    });
+
+    it('should calculate $49 at 40% off = $29.40', () => {
+      expect(calculateDiscountedPrice(49, 40)).toBe(29.4);
+    });
+
+    it('should calculate $19 at 65% off = $6.65', () => {
+      expect(calculateDiscountedPrice(19, 65)).toBe(6.65);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should return original price for negative discount', () => {
+      expect(calculateDiscountedPrice(49, -10)).toBe(49);
+    });
+
+    it('should return 0 for 100% discount on a paid tier', () => {
+      expect(calculateDiscountedPrice(49, 100)).toBe(0);
+    });
+
+    it('should handle very small prices correctly', () => {
+      expect(calculateDiscountedPrice(1, 65)).toBe(0.35);
+    });
+  });
+});
+
+describe('Homepage Pricing — Export consistency', () => {
+  it('should export calculateDiscountedPrice from Pricing.tsx', async () => {
+    const mod = await import('@client/components/features/landing/Pricing');
+    expect(typeof mod.calculateDiscountedPrice).toBe('function');
+  });
+
+  it('exported calculateDiscountedPrice should match local mirror', async () => {
+    const mod = await import('@client/components/features/landing/Pricing');
+    // Verify the exported function produces the same results
+    expect(mod.calculateDiscountedPrice(49, 65)).toBe(17.15);
+    expect(mod.calculateDiscountedPrice(19, 60)).toBe(7.6);
+    expect(mod.calculateDiscountedPrice(0, 65)).toBe(0);
+    expect(mod.calculateDiscountedPrice(9, 0)).toBe(9);
+  });
+});

--- a/tests/unit/pricing/pricing-display.unit.spec.ts
+++ b/tests/unit/pricing/pricing-display.unit.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for regional pricing display logic (Phase 3).
+ *
+ * These tests verify the pure calculation functions used by
+ * PricingCard and CreditPackSelector to show PPP-adjusted prices.
+ * They do NOT render React components — they test the math directly.
+ */
+
+// --- Pricing Card discount calculation (mirrors PricingCard.tsx logic) ---
+
+function calculateDisplayPrice(price: number, discountPercent: number): number {
+  if (discountPercent <= 0) return price;
+  return Math.round(price * (1 - discountPercent / 100) * 100) / 100;
+}
+
+// --- Credit Pack discount calculation (mirrors CreditPackSelector.tsx logic) ---
+
+function applyDiscountCents(cents: number, discountPercent: number): number {
+  if (discountPercent <= 0) return cents;
+  return Math.round(cents * (1 - discountPercent / 100));
+}
+
+function getPricePerCredit(priceInCents: number, credits: number, discountPercent: number): string {
+  const discountedCents = applyDiscountCents(priceInCents, discountPercent);
+  return (discountedCents / credits / 100).toFixed(3);
+}
+
+describe('Regional Pricing Display', () => {
+  describe('Subscription card discounted price', () => {
+    it('should calculate discounted price correctly — $9 at 65% off = $3.15', () => {
+      expect(calculateDisplayPrice(9, 65)).toBe(3.15);
+    });
+
+    it('should calculate discounted price correctly — $9 at 60% off = $3.60', () => {
+      expect(calculateDisplayPrice(9, 60)).toBe(3.6);
+    });
+
+    it('should calculate discounted price correctly — $9 at 50% off = $4.50', () => {
+      expect(calculateDisplayPrice(9, 50)).toBe(4.5);
+    });
+
+    it('should calculate discounted price correctly — $9 at 40% off = $5.40', () => {
+      expect(calculateDisplayPrice(9, 40)).toBe(5.4);
+    });
+
+    it('should not modify price for standard region (0% discount)', () => {
+      expect(calculateDisplayPrice(9, 0)).toBe(9);
+      expect(calculateDisplayPrice(19, 0)).toBe(19);
+      expect(calculateDisplayPrice(29, 0)).toBe(29);
+      expect(calculateDisplayPrice(49, 0)).toBe(49);
+    });
+
+    it('should not modify price for negative discount', () => {
+      expect(calculateDisplayPrice(9, -10)).toBe(9);
+    });
+
+    it('should handle larger plan prices — $19 at 65% off = $6.65', () => {
+      expect(calculateDisplayPrice(19, 65)).toBe(6.65);
+    });
+
+    it('should handle $29 at 50% off = $14.50', () => {
+      expect(calculateDisplayPrice(29, 50)).toBe(14.5);
+    });
+
+    it('should handle $49 at 40% off = $29.40', () => {
+      expect(calculateDisplayPrice(49, 40)).toBe(29.4);
+    });
+  });
+
+  describe('Credit pack discounted price (cents)', () => {
+    it('should calculate discounted cents correctly — 499 at 65% off = 175', () => {
+      // 499 * 0.35 = 174.65 → rounds to 175
+      expect(applyDiscountCents(499, 65)).toBe(175);
+    });
+
+    it('should calculate discounted cents correctly — 499 at 60% off = 200', () => {
+      // 499 * 0.40 = 199.6 → rounds to 200
+      expect(applyDiscountCents(499, 60)).toBe(200);
+    });
+
+    it('should calculate discounted cents correctly — 499 at 50% off = 250', () => {
+      // 499 * 0.50 = 249.5 → rounds to 250
+      expect(applyDiscountCents(499, 50)).toBe(250);
+    });
+
+    it('should not modify price for 0% discount', () => {
+      expect(applyDiscountCents(499, 0)).toBe(499);
+      expect(applyDiscountCents(999, 0)).toBe(999);
+      expect(applyDiscountCents(1999, 0)).toBe(1999);
+    });
+
+    it('should not modify price for negative discount', () => {
+      expect(applyDiscountCents(499, -5)).toBe(499);
+    });
+  });
+
+  describe('Price per credit with discount', () => {
+    it('should calculate price per credit with discount — 499 cents / 50 credits at 65% off', () => {
+      // 175 cents / 50 credits / 100 = 0.035
+      expect(getPricePerCredit(499, 50, 65)).toBe('0.035');
+    });
+
+    it('should calculate price per credit without discount — 499 cents / 50 credits at 0%', () => {
+      // 499 / 50 / 100 = 0.0998
+      expect(getPricePerCredit(499, 50, 0)).toBe('0.100');
+    });
+
+    it('should calculate price per credit for larger pack — 999 cents / 120 credits at 60% off', () => {
+      // 999 * 0.40 = 399.6 → 400 cents / 120 credits / 100 = 0.03333...
+      expect(getPricePerCredit(999, 120, 60)).toBe('0.033');
+    });
+
+    it('should calculate price per credit for largest pack — 1999 cents / 300 credits at 50% off', () => {
+      // 1999 * 0.50 = 999.5 → 1000 cents / 300 credits / 100 = 0.03333...
+      expect(getPricePerCredit(1999, 300, 50)).toBe('0.033');
+    });
+  });
+
+  describe('Regional banner visibility', () => {
+    it('should show regional banner when discountPercent > 0', () => {
+      const discountPercent = 65;
+      const showBanner = discountPercent > 0;
+      expect(showBanner).toBe(true);
+    });
+
+    it('should not show regional banner when discountPercent is 0', () => {
+      const discountPercent = 0;
+      const showBanner = discountPercent > 0;
+      expect(showBanner).toBe(false);
+    });
+
+    it('should show credit pack note when discountPercent > 0', () => {
+      const discountPercent = 40;
+      const showCreditPackNote = discountPercent > 0;
+      expect(showCreditPackNote).toBe(true);
+    });
+
+    it('should not show credit pack note for standard region', () => {
+      const discountPercent = 0;
+      const showCreditPackNote = discountPercent > 0;
+      expect(showCreditPackNote).toBe(false);
+    });
+
+    it('should show subscription note when discountPercent > 0', () => {
+      const discountPercent = 50;
+      const showSubscriptionNote = discountPercent > 0;
+      expect(showSubscriptionNote).toBe(true);
+    });
+
+    it('should not show subscription note for standard region', () => {
+      const discountPercent = 0;
+      const showSubscriptionNote = discountPercent > 0;
+      expect(showSubscriptionNote).toBe(false);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle 100% discount', () => {
+      expect(calculateDisplayPrice(9, 100)).toBe(0);
+      expect(applyDiscountCents(499, 100)).toBe(0);
+    });
+
+    it('should handle very small prices', () => {
+      expect(calculateDisplayPrice(1, 65)).toBe(0.35);
+      expect(applyDiscountCents(100, 65)).toBe(35);
+    });
+
+    it('should produce consistent results between dollar and cent calculations', () => {
+      // $9 at 65% off should match 900 cents at 65% off
+      const dollarResult = calculateDisplayPrice(9, 65);
+      const centsResult = applyDiscountCents(900, 65) / 100;
+      expect(dollarResult).toBe(centsResult);
+    });
+  });
+});

--- a/tests/unit/pricing/pricing-regions.unit.spec.ts
+++ b/tests/unit/pricing/pricing-regions.unit.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPricingRegion,
+  getDiscountPercent,
+  getDiscountedPriceInCents,
+} from '@shared/config/pricing-regions';
+
+describe('Pricing Regions', () => {
+  describe('getPricingRegion', () => {
+    it('should return south_asia for IN', () => {
+      expect(getPricingRegion('IN').region).toBe('south_asia');
+    });
+
+    it('should return southeast_asia for PH', () => {
+      expect(getPricingRegion('PH').region).toBe('southeast_asia');
+    });
+
+    it('should return standard for US', () => {
+      expect(getPricingRegion('US').region).toBe('standard');
+      expect(getPricingRegion('US').discountPercent).toBe(0);
+    });
+
+    it('should return latam for BR', () => {
+      expect(getPricingRegion('BR').region).toBe('latam');
+    });
+
+    it('should return eastern_europe for UA', () => {
+      expect(getPricingRegion('UA').region).toBe('eastern_europe');
+    });
+
+    it('should return africa for NG', () => {
+      expect(getPricingRegion('NG').region).toBe('africa');
+    });
+
+    it('should handle case-insensitive country codes', () => {
+      expect(getPricingRegion('in').region).toBe('south_asia');
+      expect(getPricingRegion('ph').region).toBe('southeast_asia');
+      expect(getPricingRegion('br').region).toBe('latam');
+    });
+
+    it('should return standard for unknown country', () => {
+      expect(getPricingRegion('XX').region).toBe('standard');
+    });
+
+    it('should return standard for Tor (T1)', () => {
+      expect(getPricingRegion('T1').region).toBe('standard');
+    });
+
+    it('should return standard for empty string', () => {
+      expect(getPricingRegion('').region).toBe('standard');
+    });
+
+    it('should return correct discount for all south_asia countries', () => {
+      for (const cc of ['IN', 'PK', 'BD', 'LK', 'NP']) {
+        expect(getPricingRegion(cc).discountPercent).toBe(65);
+      }
+    });
+
+    it('should return correct discount for all southeast_asia countries', () => {
+      for (const cc of ['PH', 'ID', 'VN', 'TH', 'MM', 'KH', 'LA']) {
+        expect(getPricingRegion(cc).discountPercent).toBe(60);
+      }
+    });
+  });
+
+  describe('getDiscountPercent', () => {
+    it('should return 65% discount for India', () => {
+      expect(getDiscountPercent('IN')).toBe(65);
+    });
+
+    it('should return 60% discount for Philippines', () => {
+      expect(getDiscountPercent('PH')).toBe(60);
+    });
+
+    it('should return 50% discount for Brazil', () => {
+      expect(getDiscountPercent('BR')).toBe(50);
+    });
+
+    it('should return 40% discount for Ukraine', () => {
+      expect(getDiscountPercent('UA')).toBe(40);
+    });
+
+    it('should return 65% discount for Nigeria', () => {
+      expect(getDiscountPercent('NG')).toBe(65);
+    });
+
+    it('should return 0% discount for US', () => {
+      expect(getDiscountPercent('US')).toBe(0);
+    });
+
+    it('should return 0% for unknown countries', () => {
+      expect(getDiscountPercent('XX')).toBe(0);
+    });
+  });
+
+  describe('getDiscountedPriceInCents', () => {
+    it('should calculate 65% off correctly for Starter ($9)', () => {
+      // $9.00 = 900 cents, 65% off = $3.15 = 315 cents
+      expect(getDiscountedPriceInCents(900, 65)).toBe(315);
+    });
+
+    it('should calculate 60% off correctly for Starter ($9)', () => {
+      // $9.00 = 900 cents, 60% off = $3.60 = 360 cents
+      expect(getDiscountedPriceInCents(900, 60)).toBe(360);
+    });
+
+    it('should calculate 50% off correctly for credit pack ($4.99)', () => {
+      // $4.99 = 499 cents, 50% off = $2.495 → rounds to 250 cents
+      expect(getDiscountedPriceInCents(499, 50)).toBe(250);
+    });
+
+    it('should return base price for 0% discount', () => {
+      expect(getDiscountedPriceInCents(900, 0)).toBe(900);
+    });
+
+    it('should return base price for negative discount', () => {
+      expect(getDiscountedPriceInCents(900, -10)).toBe(900);
+    });
+
+    it('should calculate credit pack Small (499 cents) at 65% off', () => {
+      // 499 * 0.35 = 174.65 → rounds to 175
+      expect(getDiscountedPriceInCents(499, 65)).toBe(175);
+    });
+  });
+});

--- a/tests/unit/pricing/regional-pricing-analytics.unit.spec.ts
+++ b/tests/unit/pricing/regional-pricing-analytics.unit.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  IPricingPageViewedProperties,
+  ICheckoutStartedProperties,
+  ICheckoutCompletedProperties,
+} from '@/server/analytics/types';
+
+/**
+ * Tests for Phase 4: Regional Pricing Analytics Types
+ *
+ * Validates that the analytics event interfaces include pricingRegion
+ * fields for regional dynamic pricing tracking.
+ */
+
+describe('Regional Pricing Analytics Types', () => {
+  describe('IPricingPageViewedProperties', () => {
+    it('should include pricingRegion field', () => {
+      const props: IPricingPageViewedProperties = {
+        entryPoint: 'direct',
+        currentPlan: 'free',
+        pricingRegion: 'south_asia',
+        discountPercent: 65,
+      };
+
+      expect(props.pricingRegion).toBe('south_asia');
+      expect(props.discountPercent).toBe(65);
+    });
+
+    it('should allow pricingRegion to be undefined (optional)', () => {
+      const props: IPricingPageViewedProperties = {
+        entryPoint: 'navbar',
+        currentPlan: 'pro',
+      };
+
+      expect(props.pricingRegion).toBeUndefined();
+      expect(props.discountPercent).toBeUndefined();
+    });
+
+    it('should accept standard region with 0 discount', () => {
+      const props: IPricingPageViewedProperties = {
+        entryPoint: 'direct',
+        currentPlan: 'free',
+        pricingRegion: 'standard',
+        discountPercent: 0,
+      };
+
+      expect(props.pricingRegion).toBe('standard');
+      expect(props.discountPercent).toBe(0);
+    });
+  });
+
+  describe('ICheckoutStartedProperties', () => {
+    it('should include pricingRegion field', () => {
+      const props: ICheckoutStartedProperties = {
+        priceId: 'price_123',
+        purchaseType: 'subscription',
+        sessionId: 'cs_test_123',
+        pricingRegion: 'southeast_asia',
+        discountPercent: 60,
+      };
+
+      expect(props.pricingRegion).toBe('southeast_asia');
+      expect(props.discountPercent).toBe(60);
+    });
+
+    it('should allow pricingRegion to be undefined (optional)', () => {
+      const props: ICheckoutStartedProperties = {
+        priceId: 'price_456',
+        purchaseType: 'credit_pack',
+        sessionId: 'cs_test_456',
+      };
+
+      expect(props.pricingRegion).toBeUndefined();
+    });
+  });
+
+  describe('ICheckoutCompletedProperties', () => {
+    it('should include pricingRegion field', () => {
+      const props: ICheckoutCompletedProperties = {
+        priceId: 'price_789',
+        purchaseType: 'subscription',
+        sessionId: 'cs_test_789',
+        pricingRegion: 'latam',
+      };
+
+      expect(props.pricingRegion).toBe('latam');
+    });
+
+    it('should allow pricingRegion to be undefined (optional)', () => {
+      const props: ICheckoutCompletedProperties = {
+        priceId: 'price_abc',
+        purchaseType: 'credit_pack',
+        sessionId: 'cs_test_abc',
+      };
+
+      expect(props.pricingRegion).toBeUndefined();
+    });
+
+    it('should have required fields: priceId, purchaseType, sessionId', () => {
+      const props: ICheckoutCompletedProperties = {
+        priceId: 'price_def',
+        purchaseType: 'subscription',
+        sessionId: 'cs_test_def',
+      };
+
+      expect(props).toHaveProperty('priceId');
+      expect(props).toHaveProperty('purchaseType');
+      expect(props).toHaveProperty('sessionId');
+    });
+
+    it('should accept all valid region strings', () => {
+      const regions = [
+        'standard',
+        'south_asia',
+        'southeast_asia',
+        'latam',
+        'eastern_europe',
+        'africa',
+      ];
+
+      for (const region of regions) {
+        const props: ICheckoutCompletedProperties = {
+          priceId: 'price_test',
+          purchaseType: 'subscription',
+          sessionId: 'cs_test',
+          pricingRegion: region,
+        };
+        expect(props.pricingRegion).toBe(region);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #14

## Summary
- Implements purchasing power parity pricing across 5 regions: South Asia (65% off), Southeast Asia (60%), LatAm (50%), Eastern Europe (40%), Africa (65%)
- Users see clean regional prices — no visible discount line or strikethrough
- Subscriptions use separate Stripe Price objects per region; credit packs use inline `price_data`
- Graceful degradation: falls back to standard pricing when regional Price IDs aren't configured

## Changes
| Phase | Description | Files |
|-------|-------------|-------|
| 1 | Pricing region config + geo API extension | `shared/config/pricing-regions.ts` (new), `region-classifier.ts`, `geo/route.ts` |
| 2 | Checkout routes to regional prices | `checkout/route.ts`, `env.ts` (20 new env vars), `analytics/types.ts` |
| 3 | Pricing page shows regional prices | `useRegionTier.ts`, `PricingCard.tsx`, `CreditPackSelector.tsx`, `PricingPageClient.tsx` |
| 4 | Homepage pricing + analytics tracking | `Pricing.tsx`, `analytics/types.ts` |
| 5 | Anti-abuse monitoring + edge case tests | `checkout/route.ts` (mismatch logging) |

## Test plan
- [x] 118 unit tests across 6 test files (all pass)
- [x] 2696 total unit tests pass (`yarn vitest run`)
- [x] `yarn verify` passes (tsc, lint, i18n, schema validation)
- [ ] Manual: Create regional Stripe Price objects and set env vars
- [ ] Manual: Test pricing page with `x-test-country: IN` header
- [ ] Manual: Verify checkout creates session with regional price

## Stripe Setup Required
Create 20 regional Price objects in Stripe Dashboard (4 plans × 5 regions) before deploying. Can start with just South Asia + Southeast Asia (8 prices) for validation. Credit packs need no extra setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)