### PR TITLE
fix: revenue funnel telemetry and checkout repair (#118)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit
 
+      - name: Check cron worker setup
+        run: yarn cron:check
+
   deploy:
     name: Deploy to Production
     runs-on: ubuntu-latest
@@ -88,6 +91,19 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: opennextjs-cloudflare deploy
+
+      - name: Deploy cron worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config workers/cron/wrangler.toml
+
+      - name: Verify cron schedules
+        run: yarn cron:check --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Output deployment URL
         run: echo "Deployed to ${{ steps.deploy.outputs.deployment-url }}"

--- a/app/[locale]/checkout/page.tsx
+++ b/app/[locale]/checkout/page.tsx
@@ -101,6 +101,12 @@ function CheckoutContent() {
       ...(checkoutContext?.originatingModel
         ? { originatingModel: checkoutContext.originatingModel }
         : {}),
+      ...(checkoutContext?.originatingTrigger
+        ? { originatingTrigger: checkoutContext.originatingTrigger }
+        : {}),
+      ...(checkoutContext?.attributionChain?.length
+        ? { attributionChain: checkoutContext.attributionChain }
+        : {}),
     });
     hasTrackedAuthRequiredRef.current = true;
   }, [authLoading, country, isAuthenticated, isPaywalled, priceId, regionLoading]);
@@ -156,6 +162,12 @@ function CheckoutContent() {
               ...(checkoutContext?.trigger ? { trigger: checkoutContext.trigger } : {}),
               ...(checkoutContext?.originatingModel
                 ? { originatingModel: checkoutContext.originatingModel }
+                : {}),
+              ...(checkoutContext?.originatingTrigger
+                ? { originatingTrigger: checkoutContext.originatingTrigger }
+                : {}),
+              ...(checkoutContext?.attributionChain?.length
+                ? { attributionChain: checkoutContext.attributionChain }
                 : {}),
             });
             hasTrackedCheckoutOpenRef.current = true;

--- a/app/api/analytics/event/route.ts
+++ b/app/api/analytics/event/route.ts
@@ -69,6 +69,8 @@ const ALLOWED_EVENTS = [
   // Batch limit events
   'batch_limit_modal_shown',
   'batch_limit_upgrade_clicked',
+  'batch_limit_quick_buy_clicked',
+  'batch_limit_see_plans_clicked',
   'batch_limit_partial_add_clicked',
   'batch_limit_modal_closed',
 
@@ -103,6 +105,15 @@ const ALLOWED_EVENTS = [
   // Country paywall events
   'paywall_shown',
   'paywall_hit',
+  // Engagement-based first-purchase discount events
+  'engagement_discount_eligible',
+  'engagement_discount_toast_shown',
+  'engagement_discount_toast_dismissed',
+  'engagement_discount_offer_shown',
+  'engagement_discount_offer_dismissed',
+  'engagement_discount_cta_clicked',
+  'engagement_discount_checkout_started',
+  'engagement_discount_redeemed',
 ] as const;
 
 // Type for allowed events (excludes $identify which is server-side only)

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -688,6 +688,23 @@ export async function POST(request: NextRequest) {
     try {
       session = await stripe.checkout.sessions.create(sessionParams);
     } catch (sessionError) {
+      const checkoutMode = resolvedPrice?.type === 'pack' ? 'payment' : 'subscription';
+      console.error('[CHECKOUT_SESSION_CREATE_ERROR]', {
+        priceId: validatedPriceId,
+        resolvedPriceType: resolvedPrice?.type,
+        checkoutMode,
+        pricingRegion: resolvedPricingRegion,
+        discountPercent: regionalDiscountPercent,
+        engagementDiscountPercent,
+        checkoutOfferDiscountPercent,
+        uiMode,
+        stripeErrorCode: sessionError instanceof Stripe.errors.StripeError ? sessionError.code : null,
+        stripeErrorType: sessionError instanceof Stripe.errors.StripeError ? sessionError.type : null,
+        stripeErrorParam: sessionError instanceof Stripe.errors.StripeError ? sessionError.param : null,
+        stripeErrorMessage:
+          sessionError instanceof Error ? sessionError.message : 'Unknown Stripe error',
+      });
+
       // If the stored customer ID is stale (deleted in Stripe), create a fresh one and retry once
       if (
         sessionError instanceof Stripe.errors.StripeInvalidRequestError &&

--- a/app/api/cron/refresh-3kings-sitemap/route.ts
+++ b/app/api/cron/refresh-3kings-sitemap/route.ts
@@ -4,7 +4,8 @@
  * Fetches GSC data, scores blog pages using the 3-Kings technique, and
  * persists the latest batch into the three_kings_sitemap_entries table.
  *
- * Triggered by: Cloudflare Cron Trigger (weekly)
+ * Triggered by: Cloudflare Cron Trigger (daily at 04:30 UTC)
+ * Schedule: 30 4 * * * (daily at 4:30 AM UTC)
  */
 
 import { NextRequest, NextResponse } from 'next/server';

--- a/app/api/gallery/route.ts
+++ b/app/api/gallery/route.ts
@@ -10,6 +10,7 @@ import { ErrorCodes, createErrorResponse, serializeError } from '@shared/utils/e
 import {
   listImages,
   saveImage,
+  saveUploadedImage,
   getUsage,
   type ISaveImageMetadata,
 } from '@server/services/galleryStorage.service';
@@ -142,21 +143,50 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json(body, { status });
     }
 
-    // 2. Parse and validate request body
-    const body = await req.json();
-    const validatedInput: ISaveImageInput = saveImageSchema.parse(body);
+    const contentType = req.headers.get('content-type') ?? '';
+    let metadata: ISaveImageMetadata;
+    let result;
 
-    // 3. Prepare metadata
-    const metadata: ISaveImageMetadata = {
-      filename: validatedInput.filename,
-      width: validatedInput.width,
-      height: validatedInput.height,
-      modelUsed: validatedInput.modelUsed,
-      processingMode: validatedInput.processingMode,
-    };
+    if (contentType.includes('multipart/form-data')) {
+      const formData = await req.formData();
+      const file = formData.get('file');
+      if (!(file instanceof File)) {
+        const { body, status } = createErrorResponse(
+          ErrorCodes.VALIDATION_ERROR,
+          'Image file is required',
+          400
+        );
+        return NextResponse.json(body, { status });
+      }
 
-    // 4. Save the image
-    const result = await saveImage(userId, validatedInput.imageUrl, metadata);
+      const widthValue = formData.get('width');
+      const heightValue = formData.get('height');
+      metadata = {
+        filename: String(formData.get('filename') || file.name || 'image.webp'),
+        width: typeof widthValue === 'string' ? parseInt(widthValue, 10) : undefined,
+        height: typeof heightValue === 'string' ? parseInt(heightValue, 10) : undefined,
+        modelUsed: String(formData.get('modelUsed') || 'unknown'),
+        processingMode: String(
+          formData.get('processingMode') || 'both'
+        ) as ISaveImageMetadata['processingMode'],
+      };
+
+      const fileBuffer = Buffer.from(await file.arrayBuffer());
+      result = await saveUploadedImage(userId, fileBuffer, file.type || 'image/webp', metadata);
+    } else {
+      const body = await req.json();
+      const validatedInput: ISaveImageInput = saveImageSchema.parse(body);
+
+      metadata = {
+        filename: validatedInput.filename,
+        width: validatedInput.width,
+        height: validatedInput.height,
+        modelUsed: validatedInput.modelUsed,
+        processingMode: validatedInput.processingMode,
+      };
+
+      result = await saveImage(userId, validatedInput.imageUrl, metadata);
+    }
 
     // 5. Get updated usage stats
     const usage = await getUsage(userId);
@@ -173,6 +203,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       data: {
         ...result.image,
         signed_url: result.signedUrl,
+        thumbnail_signed_url: result.thumbnailSignedUrl,
       },
       usage,
     };

--- a/client/components/dashboard/Gallery.tsx
+++ b/client/components/dashboard/Gallery.tsx
@@ -195,12 +195,13 @@ export function Gallery(): JSX.Element {
           <>
             {/* Image Grid */}
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {listState.images.map(image => (
+              {listState.images.map((image, index) => (
                 <GalleryImageCard
                   key={image.id}
                   image={image}
                   onDelete={handleDeleteImage}
                   isDeleting={isDeleting}
+                  eagerLoad={index < 4}
                 />
               ))}
             </div>

--- a/client/components/dashboard/GalleryImageCard.tsx
+++ b/client/components/dashboard/GalleryImageCard.tsx
@@ -18,6 +18,8 @@ interface IGalleryImageCardProps {
   onDelete: (imageId: string) => Promise<void>;
   /** Whether a delete operation is in progress */
   isDeleting?: boolean;
+  /** Whether this thumbnail is likely above the fold */
+  eagerLoad?: boolean;
 }
 
 /**
@@ -146,6 +148,7 @@ export const GalleryImageCard: React.FC<IGalleryImageCardProps> = ({
   image,
   onDelete,
   isDeleting = false,
+  eagerLoad = false,
 }) => {
   const t = useTranslations('dashboard.gallery');
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -210,6 +213,7 @@ export const GalleryImageCard: React.FC<IGalleryImageCardProps> = ({
             fill
             sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
             className="object-cover"
+            loading={eagerLoad ? 'eager' : 'lazy'}
             unoptimized
           />
 

--- a/client/components/dashboard/GalleryImageCard.tsx
+++ b/client/components/dashboard/GalleryImageCard.tsx
@@ -208,10 +208,10 @@ export const GalleryImageCard: React.FC<IGalleryImageCardProps> = ({
         {/* Image Container */}
         <div className="relative aspect-square bg-surface-light">
           <Image
-            src={image.signed_url || ''}
+            src={image.thumbnail_signed_url || image.signed_url || ''}
             alt={image.original_filename}
             fill
-            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 256px"
             className="object-cover"
             loading={eagerLoad ? 'eager' : 'lazy'}
             unoptimized

--- a/client/components/engagement-discount/EngagementDiscountBanner.tsx
+++ b/client/components/engagement-discount/EngagementDiscountBanner.tsx
@@ -15,7 +15,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { X, Clock, Sparkles } from 'lucide-react';
 import { useEngagementDiscountStore } from '@client/store/engagementDiscountStore';
 import { analytics } from '@client/analytics';
-import { DISCOUNT_TARGET_PACK, formatCountdown } from '@shared/config/engagement-discount';
+import { DISCOUNT_TARGET_PACK, formatCountdown, ENGAGEMENT_DISCOUNT_CONFIG } from '@shared/config/engagement-discount';
 import { cn } from '@client/utils/cn';
 import { setCheckoutTrackingContext } from '@client/utils/checkoutTrackingContext';
 
@@ -109,6 +109,14 @@ export const EngagementDiscountBanner: React.FC<IEngagementDiscountBannerProps> 
   // Track impression once per session — guard prevents re-firing on remount or offer reference changes
   useEffect(() => {
     if (showToast && offer && !hasTrackedImpression) {
+      // Canonical event for banner/offer reporting
+      analytics.track('engagement_discount_offer_shown', {
+        discountPercent: offer.discountPercent,
+        originalPriceCents: offer.originalPriceCents,
+        discountedPriceCents: offer.discountedPriceCents,
+        engagement_discount_source: resolvedSource,
+      });
+      // Legacy toast event for backward compatibility with existing dashboards
       analytics.track('engagement_discount_toast_shown', {
         discountPercent: offer.discountPercent,
         originalPriceCents: offer.originalPriceCents,
@@ -124,19 +132,26 @@ export const EngagementDiscountBanner: React.FC<IEngagementDiscountBannerProps> 
     setTimeout(() => {
       dismissToast();
       setIsDismissed(true);
+      analytics.track('engagement_discount_offer_dismissed', {
+        timeRemainingSeconds: remainingSeconds,
+        engagement_discount_source: resolvedSource,
+      });
+      // Legacy toast event for backward compatibility with existing dashboards
       analytics.track('engagement_discount_toast_dismissed', {
         timeRemainingSeconds: remainingSeconds,
       });
     }, 300);
-  }, [dismissToast, remainingSeconds]);
+  }, [dismissToast, remainingSeconds, resolvedSource]);
 
   const handleClaimClick = useCallback(() => {
     analytics.track('engagement_discount_cta_clicked', {
       timeRemainingSeconds: remainingSeconds,
+      engagement_discount_source: resolvedSource,
+      targetPriceId: ENGAGEMENT_DISCOUNT_CONFIG.targetPackKey,
     });
     setCheckoutTrackingContext({ trigger: 'engagement_discount_banner' });
     onClaimDiscount();
-  }, [onClaimDiscount, remainingSeconds]);
+  }, [onClaimDiscount, remainingSeconds, resolvedSource]);
 
   if (!showToast || !offer || isDismissed) {
     return null;

--- a/client/components/features/image-processing/ImageComparison.tsx
+++ b/client/components/features/image-processing/ImageComparison.tsx
@@ -1,12 +1,20 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { ArrowLeftRight, Download, ZoomIn, ZoomOut } from 'lucide-react';
-import { Button } from '@client/components/ui/Button';
+import { ArrowLeftRight, Check, Download, ImagePlus, ZoomIn, ZoomOut } from 'lucide-react';
 import { analytics } from '@client/analytics/analyticsClient';
+import { useTranslations } from 'next-intl';
+
+export interface IImageDimensions {
+  width: number;
+  height: number;
+}
 
 interface IImageComparisonProps {
   beforeUrl: string;
   afterUrl: string;
   onDownload: () => void;
+  onSaveToGallery?: (dimensions?: IImageDimensions) => void;
+  isSavingToGallery?: boolean;
+  isSavedToGallery?: boolean;
   /** Whether the after image has transparency (e.g., from bg-removal). Auto-detected from blob: URLs if not provided. */
   hasTransparency?: boolean;
   /** Scale factor applied to the image (e.g., 2, 4, 8). Used for analytics tracking. */
@@ -19,13 +27,18 @@ export const ImageComparison: React.FC<IImageComparisonProps> = ({
   beforeUrl,
   afterUrl,
   onDownload,
+  onSaveToGallery,
+  isSavingToGallery = false,
+  isSavedToGallery = false,
   hasTransparency,
   upscaleFactor,
   modelUsed,
 }) => {
+  const t = useTranslations('workspace.imageComparison');
   const [sliderPosition, setSliderPosition] = useState(50);
   const [isDragging, setIsDragging] = useState(false);
   const [zoom, setZoom] = useState(1);
+  const [afterDimensions, setAfterDimensions] = useState<IImageDimensions | undefined>();
   const containerRef = useRef<HTMLDivElement>(null);
   const previewTrackedRef = useRef(false);
 
@@ -121,27 +134,48 @@ export const ImageComparison: React.FC<IImageComparisonProps> = ({
       <div className="p-3 md:p-4 border-b border-border flex flex-wrap md:flex-nowrap justify-between items-center gap-2 shrink-0">
         <div className="flex items-center">
           <span className="inline-flex items-center px-2 md:px-2.5 py-0.5 rounded-full text-xs font-medium bg-success/20 text-success whitespace-nowrap">
-            ✓ Enhanced
+            {t('enhanced')}
           </span>
         </div>
         <div className="flex items-center gap-1 md:gap-2">
           <button
             onClick={toggleZoom}
             className="p-2 text-muted-foreground hover:text-accent hover:bg-accent/10 rounded-md transition-colors"
-            title="Toggle Zoom"
+            title={t('toggleZoom')}
           >
             {zoom === 1 ? <ZoomIn size={18} /> : <ZoomOut size={18} />}
           </button>
-          <Button
-            variant="primary"
-            size="sm"
-            icon={<Download size={16} />}
+          {onSaveToGallery && (
+            <button
+              onClick={() => onSaveToGallery(afterDimensions)}
+              disabled={isSavedToGallery || isSavingToGallery}
+              className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-cyan-300/50 bg-cyan-400/18 px-3 text-xs font-semibold text-cyan-100 shadow-sm transition-colors hover:border-cyan-200/70 hover:bg-cyan-400/26 hover:text-white disabled:opacity-70 disabled:cursor-not-allowed"
+              title={isSavedToGallery ? t('savedToGallery') : t('saveToGallery')}
+              aria-label={isSavedToGallery ? t('savedToGallery') : t('saveToGallery')}
+              data-driver="save-gallery-button"
+            >
+              {isSavedToGallery ? (
+                <Check size={16} />
+              ) : isSavingToGallery ? (
+                <span className="h-4 w-4 rounded-full border-2 border-current border-t-transparent animate-spin" />
+              ) : (
+                <ImagePlus size={16} />
+              )}
+              <span className="hidden sm:inline">
+                {isSavedToGallery ? t('savedToGallery') : t('saveToGallery')}
+              </span>
+              <span className="sm:hidden">{isSavedToGallery ? t('saved') : t('save')}</span>
+            </button>
+          )}
+          <button
             onClick={onDownload}
+            className="inline-flex h-8 items-center justify-center gap-2 rounded-lg bg-accent px-3 text-xs font-medium text-white shadow-sm transition-colors hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
             data-driver="download-button"
           >
-            <span className="hidden sm:inline">Download Result</span>
-            <span className="sm:hidden">Download</span>
-          </Button>
+            <Download size={16} />
+            <span className="hidden sm:inline">{t('downloadResult')}</span>
+            <span className="sm:hidden">{t('download')}</span>
+          </button>
         </div>
       </div>
 
@@ -168,6 +202,13 @@ export const ImageComparison: React.FC<IImageComparisonProps> = ({
               loading="eager"
               decoding="async"
               fetchPriority="high"
+              onLoad={event => {
+                const image = event.currentTarget;
+                setAfterDimensions({
+                  width: image.naturalWidth,
+                  height: image.naturalHeight,
+                });
+              }}
             />
           </div>
 
@@ -200,10 +241,10 @@ export const ImageComparison: React.FC<IImageComparisonProps> = ({
 
         {/* Labels */}
         <div className="absolute bottom-4 left-4 bg-black/50 text-white text-xs px-2 py-1 rounded pointer-events-none">
-          Original
+          {t('original')}
         </div>
         <div className="absolute bottom-4 right-4 bg-accent/80 text-white text-xs px-2 py-1 rounded pointer-events-none">
-          Enhanced
+          {t('enhancedLabel')}
         </div>
       </div>
     </div>

--- a/client/components/features/workspace/BatchLimitModal.tsx
+++ b/client/components/features/workspace/BatchLimitModal.tsx
@@ -64,13 +64,23 @@ export const BatchLimitModal: React.FC<IBatchLimitModalProps> = ({
 
   const handleQuickBuyClick = () => {
     setCheckoutTrackingContext({ trigger: 'batch_limit' });
-    analytics.track('batch_limit_quick_buy_clicked', {
+    const baseProperties = {
       limit,
       attempted,
       currentCount,
+      availableSlots,
       serverEnforced,
       userType: limit <= 5 ? 'free' : 'paid',
       copyVariant,
+    };
+    // Canonical event for funnel reporting
+    analytics.track('batch_limit_upgrade_clicked', {
+      ...baseProperties,
+      cta: 'quick_buy',
+    });
+    // Legacy detail event for backward compatibility
+    analytics.track('batch_limit_quick_buy_clicked', {
+      ...baseProperties,
       quickBuy: true,
     });
     onClose();
@@ -80,13 +90,23 @@ export const BatchLimitModal: React.FC<IBatchLimitModalProps> = ({
 
   const handleSeePlansClick = () => {
     setCheckoutTrackingContext({ trigger: 'batch_limit' });
-    analytics.track('batch_limit_see_plans_clicked', {
+    const baseProperties = {
       limit,
       attempted,
       currentCount,
+      availableSlots,
       serverEnforced,
       userType: limit <= 5 ? 'free' : 'paid',
       copyVariant,
+    };
+    // Canonical event for funnel reporting
+    analytics.track('batch_limit_upgrade_clicked', {
+      ...baseProperties,
+      cta: 'see_plans',
+    });
+    // Legacy detail event for backward compatibility
+    analytics.track('batch_limit_see_plans_clicked', {
+      ...baseProperties,
       quickBuy: false,
     });
     onClose();

--- a/client/components/features/workspace/PreviewArea.tsx
+++ b/client/components/features/workspace/PreviewArea.tsx
@@ -266,7 +266,7 @@ export const PreviewArea: React.FC<IPreviewAreaProps> = ({
     activeItem?.status === ProcessingStatus.COMPLETED;
 
   if (activeItem.status === ProcessingStatus.COMPLETED && activeItem.processedUrl) {
-    const canSaveToGallery = /^https?:\/\//i.test(activeItem.processedUrl);
+    const canSaveToGallery = /^(https?:|blob:)/i.test(activeItem.processedUrl);
 
     return (
       <div className="w-full h-full md:h-[65vh] md:min-h-[400px] flex flex-col">

--- a/client/components/features/workspace/PreviewArea.tsx
+++ b/client/components/features/workspace/PreviewArea.tsx
@@ -1,5 +1,7 @@
 import { IBatchItem, ProcessingStage, ProcessingStatus } from '@/shared/types/coreflow.types';
-import ImageComparison from '@client/components/features/image-processing/ImageComparison';
+import ImageComparison, {
+  type IImageDimensions,
+} from '@client/components/features/image-processing/ImageComparison';
 import { Button } from '@client/components/ui/Button';
 import { AlertTriangle, Check, Layers, Loader2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
@@ -13,11 +15,14 @@ export interface IBatchProgress {
 export interface IPreviewAreaProps {
   activeItem: IBatchItem | null;
   onDownload: (url: string, filename: string) => void;
+  onSaveToGallery?: (item: IBatchItem, dimensions?: IImageDimensions) => void;
   onRetry: (item: IBatchItem) => void;
   selectedModel?: string;
   batchProgress?: IBatchProgress | null;
   isProcessingBatch?: boolean;
   isFreeUser?: boolean;
+  savingGalleryItemId?: string | null;
+  savedGalleryItemIds?: ReadonlySet<string>;
 }
 
 // Extracted Components
@@ -170,11 +175,14 @@ const MODEL_PROCESSING_TIMES: Record<string, number> = {
 export const PreviewArea: React.FC<IPreviewAreaProps> = ({
   activeItem,
   onDownload,
+  onSaveToGallery,
   onRetry,
   selectedModel = 'auto',
   batchProgress,
   isProcessingBatch = false,
   isFreeUser: _isFreeUser = false,
+  savingGalleryItemId,
+  savedGalleryItemIds,
 }) => {
   const t = useTranslations('workspace');
 
@@ -258,6 +266,8 @@ export const PreviewArea: React.FC<IPreviewAreaProps> = ({
     activeItem?.status === ProcessingStatus.COMPLETED;
 
   if (activeItem.status === ProcessingStatus.COMPLETED && activeItem.processedUrl) {
+    const canSaveToGallery = /^https?:\/\//i.test(activeItem.processedUrl);
+
     return (
       <div className="w-full h-full md:h-[65vh] md:min-h-[400px] flex flex-col">
         <div className="mb-1 md:mb-4 flex justify-between items-center shrink-0">
@@ -275,6 +285,13 @@ export const PreviewArea: React.FC<IPreviewAreaProps> = ({
             beforeUrl={activeItem.previewUrl}
             afterUrl={activeItem.processedUrl}
             onDownload={() => onDownload(activeItem.processedUrl!, activeItem.file.name)}
+            onSaveToGallery={
+              onSaveToGallery && canSaveToGallery
+                ? dimensions => onSaveToGallery(activeItem, dimensions)
+                : undefined
+            }
+            isSavingToGallery={savingGalleryItemId === activeItem.id}
+            isSavedToGallery={savedGalleryItemIds?.has(activeItem.id) ?? false}
           />
 
           {/* Waiting for next batch item overlay */}

--- a/client/components/features/workspace/Workspace.tsx
+++ b/client/components/features/workspace/Workspace.tsx
@@ -19,6 +19,7 @@ import { ErrorAlert } from '@client/components/stripe/ErrorAlert';
 import { TabButton } from '@client/components/ui/TabButton';
 import { analytics } from '@client/analytics';
 import { useEngagementTracker } from '@client/hooks/useEngagementTracker';
+import { useGallery } from '@client/hooks/useGallery';
 import { useOnboardingDriver } from '@client/hooks/useOnboardingDriver';
 import { useRegionTier } from '@client/hooks/useRegionTier';
 import { useUpgradeAbandonmentDetector } from '@client/hooks/useUpgradeAbandonmentDetector';
@@ -54,6 +55,7 @@ import { ProgressSteps, checkIsFirstTimeUser, markFirstUploadCompleted } from '.
 import { SampleImageSelector } from './SampleImageSelector';
 import { ISampleImage } from '@shared/config/sample-images.config';
 import { FirstDownloadCelebration } from './FirstDownloadCelebration';
+import type { IImageDimensions } from '@client/components/features/image-processing/ImageComparison';
 
 type MobileTab = 'upload' | 'preview' | 'queue';
 
@@ -82,6 +84,7 @@ const Workspace: React.FC = () => {
   const { isFreeUser, profile } = useUserData();
   const searchParams = useSearchParams();
   const { trackUpscale, trackDownload, trackModelSwitch } = useEngagementTracker();
+  const { saveImage: saveImageToGallery, isSaving: isSavingToGallery } = useGallery();
   const { isPaywalled, country } = useRegionTier();
 
   // Abandonment recovery: if user clicks upgrade but doesn't checkout within 10 min,
@@ -203,6 +206,8 @@ const Workspace: React.FC = () => {
   const [showCelebration, setShowCelebration] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [downloadCount, setDownloadCount] = useState(0);
+  const [savingGalleryItemId, setSavingGalleryItemId] = useState<string | null>(null);
+  const [savedGalleryItemIds, setSavedGalleryItemIds] = useState<Set<string>>(() => new Set());
   const wasProcessingRef = React.useRef(false);
   const firstUploadCompletedTrackedRef = React.useRef(false);
   const firstUploadSourceRef = React.useRef<'sample' | 'upload'>('upload');
@@ -344,6 +349,25 @@ const Workspace: React.FC = () => {
 
   const handleDownloadSingle = async (url: string, filename: string) => {
     await executeDownload(url, filename);
+  };
+
+  const handleSaveToGallery = async (item: IBatchItem, dimensions?: IImageDimensions) => {
+    if (!item.processedUrl || isSavingToGallery || savingGalleryItemId) return;
+
+    setSavingGalleryItemId(item.id);
+    const saved = await saveImageToGallery({
+      imageUrl: item.processedUrl,
+      filename: item.file.name,
+      width: dimensions?.width,
+      height: dimensions?.height,
+      modelUsed: config.qualityTier,
+      processingMode: 'upscale',
+    });
+
+    if (saved) {
+      setSavedGalleryItemIds(prev => new Set(prev).add(item.id));
+    }
+    setSavingGalleryItemId(null);
   };
 
   // Handler for partial add from modal
@@ -609,11 +633,14 @@ const Workspace: React.FC = () => {
             <PreviewArea
               activeItem={activeItem}
               onDownload={handleDownloadSingle}
+              onSaveToGallery={handleSaveToGallery}
               onRetry={(item: IBatchItem) => processSingleItem(item, config)}
               selectedModel={config.qualityTier}
               batchProgress={batchProgress}
               isProcessingBatch={isProcessingBatch}
               isFreeUser={isFreeUser}
+              savingGalleryItemId={savingGalleryItemId}
+              savedGalleryItemIds={savedGalleryItemIds}
             />
           </div>
 

--- a/client/components/navigation/NavBar.tsx
+++ b/client/components/navigation/NavBar.tsx
@@ -78,7 +78,6 @@ export const NavBar = (): JSX.Element => {
               width={100}
               height={40}
               className="xs:hidden h-8 w-auto drop-shadow-[0_2px_8px_rgba(59,130,246,0.3)]"
-              priority
             />
             {/* Full logo for desktop */}
             <Image
@@ -87,7 +86,6 @@ export const NavBar = (): JSX.Element => {
               width={200}
               height={40}
               className="hidden xs:block h-10 w-auto drop-shadow-[0_2px_8px_rgba(59,130,246,0.3)]"
-              priority
             />
           </a>
 
@@ -338,6 +336,14 @@ export const NavBar = (): JSX.Element => {
                       </li>
                       <li>
                         <a
+                          href={localizedPath('/dashboard/gallery')}
+                          className="block px-4 py-2 text-sm text-muted-foreground hover:bg-surface/10 hover:text-white rounded-lg transition-colors cursor-pointer"
+                        >
+                          {t('gallery')}
+                        </a>
+                      </li>
+                      <li>
+                        <a
                           href={localizedPath('/dashboard/billing')}
                           className="block px-4 py-2 text-sm text-muted-foreground hover:bg-surface/10 hover:text-white rounded-lg transition-colors cursor-pointer"
                         >
@@ -414,12 +420,20 @@ export const NavBar = (): JSX.Element => {
           <div className="lg:hidden border-t border-border bg-surface">
             <nav className="flex flex-col px-4 py-4 space-y-2">
               {isAuthenticated && (
-                <a
-                  href={localizedPath('/dashboard')}
-                  className="block px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-surface/10 hover:text-white rounded-lg transition-colors"
-                >
-                  {t('dashboard')}
-                </a>
+                <>
+                  <a
+                    href={localizedPath('/dashboard')}
+                    className="block px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-surface/10 hover:text-white rounded-lg transition-colors"
+                  >
+                    {t('dashboard')}
+                  </a>
+                  <a
+                    href={localizedPath('/dashboard/gallery')}
+                    className="block px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-surface/10 hover:text-white rounded-lg transition-colors"
+                  >
+                    {t('gallery')}
+                  </a>
+                </>
               )}
               <a
                 href={localizedPath('/features')}

--- a/client/hooks/useCheckoutSession.ts
+++ b/client/hooks/useCheckoutSession.ts
@@ -215,8 +215,25 @@ export function useCheckoutSession({
         console.error('Failed to create checkout session:', err);
         const errorMessage = err instanceof Error ? err.message : 'Failed to load checkout';
         const code = (err as { code?: string })?.code ?? null;
+        const stripeErrorType = (err as { type?: string })?.type ?? null;
+        const stripeErrorParam = (err as { param?: string })?.param ?? null;
         setError(errorMessage);
         setErrorCode(code);
+
+        const checkoutContext = getCheckoutTrackingContext();
+        const uiMode = isMobileViewport() ? 'hosted' : 'embedded';
+        analytics.track('checkout_error', {
+          errorType: 'network_error',
+          errorMessage,
+          step: 'plan_selection',
+          priceId,
+          trigger: checkoutContext?.trigger || 'unknown',
+          source: 'checkout_modal',
+          uiMode,
+          errorCode: code,
+          stripeErrorType,
+          stripeErrorParam,
+        });
         trackError('network_error', errorMessage, 'plan_selection');
         showToast({
           message: errorMessage,

--- a/client/hooks/useGallery.ts
+++ b/client/hooks/useGallery.ts
@@ -84,6 +84,10 @@ type ApiErrorBody = {
   code?: string;
 };
 
+const GALLERY_WEBP_CONFIG = {
+  quality: 0.82,
+};
+
 async function getAuthHeaders(): Promise<Record<string, string>> {
   const supabase = createClient();
   const {
@@ -117,6 +121,85 @@ function getApiErrorMessage(data: ApiErrorBody | null, fallback: string): string
   }
 
   return fallback;
+}
+
+function getWebpFilename(filename: string): string {
+  const baseName = filename.replace(/\.[^.]+$/, '');
+  return `${baseName || 'image'}.webp`;
+}
+
+function getImageFetchUrlForConversion(imageUrl: string): string {
+  if (imageUrl.startsWith('blob:')) {
+    return imageUrl;
+  }
+
+  try {
+    const url = new URL(imageUrl);
+    const hostname = url.hostname.toLowerCase();
+    const isReplicateUrl =
+      hostname === 'replicate.delivery' ||
+      hostname.endsWith('.replicate.delivery') ||
+      hostname === 'replicate.com' ||
+      hostname.endsWith('.replicate.com');
+
+    if (isReplicateUrl) {
+      return `/api/proxy-image?url=${encodeURIComponent(imageUrl)}`;
+    }
+  } catch {
+    return imageUrl;
+  }
+
+  return imageUrl;
+}
+
+async function canvasToWebpBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => {
+        if (!blob) {
+          reject(new Error('Browser failed to encode WebP image'));
+          return;
+        }
+        resolve(blob);
+      },
+      'image/webp',
+      GALLERY_WEBP_CONFIG.quality
+    );
+  });
+}
+
+async function convertImageUrlToWebpFile(
+  imageUrl: string,
+  filename: string
+): Promise<{ file: File; width: number; height: number }> {
+  const response = await fetch(getImageFetchUrlForConversion(imageUrl));
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image for WebP conversion: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    bitmap.close();
+    throw new Error('Browser canvas is unavailable');
+  }
+
+  ctx.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
+  const width = bitmap.width;
+  const height = bitmap.height;
+  bitmap.close();
+
+  const webpBlob = await canvasToWebpBlob(canvas);
+  return {
+    file: new File([webpBlob], getWebpFilename(filename), { type: 'image/webp' }),
+    width,
+    height,
+  };
 }
 
 /**
@@ -254,21 +337,45 @@ export function useGallery(): IUseGalleryReturn {
       setLastSavedImageId(null);
 
       try {
-        const response = await fetch('/api/gallery', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(await getAuthHeaders()),
-          },
-          body: JSON.stringify({
-            imageUrl: input.imageUrl,
-            filename: input.filename,
-            width: input.width,
-            height: input.height,
-            modelUsed: input.modelUsed,
-            processingMode: input.processingMode,
-          }),
-        });
+        const authHeaders = await getAuthHeaders();
+        let response: Response;
+
+        try {
+          const converted = await convertImageUrlToWebpFile(input.imageUrl, input.filename);
+          const formData = new FormData();
+          formData.append('file', converted.file);
+          formData.append('filename', converted.file.name);
+          formData.append('width', converted.width.toString());
+          formData.append('height', converted.height.toString());
+          if (input.modelUsed) formData.append('modelUsed', input.modelUsed);
+          if (input.processingMode) formData.append('processingMode', input.processingMode);
+
+          response = await fetch('/api/gallery', {
+            method: 'POST',
+            headers: authHeaders,
+            body: formData,
+          });
+        } catch (conversionError) {
+          console.warn(
+            '[useGallery] WebP conversion failed, falling back to URL save:',
+            conversionError
+          );
+          response = await fetch('/api/gallery', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...authHeaders,
+            },
+            body: JSON.stringify({
+              imageUrl: input.imageUrl,
+              filename: input.filename,
+              width: input.width,
+              height: input.height,
+              modelUsed: input.modelUsed,
+              processingMode: input.processingMode,
+            }),
+          });
+        }
 
         const data = (await response.json()) as ApiErrorBody & {
           success?: boolean;

--- a/client/hooks/useGallery.ts
+++ b/client/hooks/useGallery.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { useToastStore } from '@client/store/toastStore';
 import { analytics } from '@client/analytics/analyticsClient';
+import { createClient } from '@shared/utils/supabase/client';
 import { GALLERY_QUERY_CONFIG } from '@shared/config/gallery.config';
 import type {
   IGalleryStats,
@@ -77,6 +78,47 @@ const initialListState: IGalleryListState = {
   hasMore: false,
 };
 
+type ApiErrorBody = {
+  message?: string;
+  error?: string | { message?: string; code?: string };
+  code?: string;
+};
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.access_token) {
+    throw new Error('Authentication required');
+  }
+
+  return {
+    Authorization: `Bearer ${session.access_token}`,
+  };
+}
+
+function getApiErrorMessage(data: ApiErrorBody | null, fallback: string): string {
+  if (!data) {
+    return fallback;
+  }
+
+  if (data.message) {
+    return data.message;
+  }
+
+  if (typeof data.error === 'string') {
+    return data.error;
+  }
+
+  if (data.error?.message) {
+    return data.error.message;
+  }
+
+  return fallback;
+}
+
 /**
  * Hook for managing gallery operations
  * Provides save, delete, list, and usage tracking functionality
@@ -100,9 +142,12 @@ export function useGallery(): IUseGalleryReturn {
     setError(null);
 
     try {
-      const response = await fetch('/api/gallery?page_size=1');
+      const response = await fetch('/api/gallery?page_size=1', {
+        headers: await getAuthHeaders(),
+      });
       if (!response.ok) {
-        throw new Error('Failed to fetch gallery usage');
+        const data = (await response.json().catch(() => null)) as ApiErrorBody | null;
+        throw new Error(getApiErrorMessage(data, 'Failed to fetch gallery usage'));
       }
 
       const data = await response.json();
@@ -133,14 +178,23 @@ export function useGallery(): IUseGalleryReturn {
           sort_order: GALLERY_QUERY_CONFIG.defaultSortOrder,
         });
 
-        const response = await fetch(`/api/gallery?${params.toString()}`);
-        const data = await response.json();
+        const response = await fetch(`/api/gallery?${params.toString()}`, {
+          headers: await getAuthHeaders(),
+        });
+        const data = (await response.json()) as ApiErrorBody & {
+          success?: boolean;
+          data?: IGalleryListResponse;
+          usage?: IGalleryStats;
+        };
 
         if (!response.ok) {
-          throw new Error(data.message || data.error || 'Failed to fetch images');
+          throw new Error(getApiErrorMessage(data, 'Failed to fetch images'));
         }
 
-        const responseData: IGalleryListResponse = data.data;
+        const responseData = data.data;
+        if (!responseData) {
+          throw new Error('Failed to fetch images');
+        }
 
         setListState(prev => ({
           images: append ? [...prev.images, ...responseData.images] : responseData.images,
@@ -204,6 +258,7 @@ export function useGallery(): IUseGalleryReturn {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...(await getAuthHeaders()),
           },
           body: JSON.stringify({
             imageUrl: input.imageUrl,
@@ -215,11 +270,16 @@ export function useGallery(): IUseGalleryReturn {
           }),
         });
 
-        const data = await response.json();
+        const data = (await response.json()) as ApiErrorBody & {
+          success?: boolean;
+          data?: IGalleryListResponse['images'][0];
+          usage?: IGalleryStats;
+        };
 
         if (!response.ok) {
           // Handle gallery limit exceeded
-          if (response.status === 403 || data.code === 'FORBIDDEN') {
+          const errorCode = typeof data.error === 'object' ? data.error.code : data.code;
+          if (response.status === 403 || errorCode === 'FORBIDDEN') {
             analytics.track('gallery_limit_reached', {
               currentCount: usage?.current_count ?? 0,
               maxAllowed: usage?.max_allowed ?? 0,
@@ -235,7 +295,7 @@ export function useGallery(): IUseGalleryReturn {
           }
 
           // Handle authentication error
-          if (response.status === 401 || data.code === 'UNAUTHORIZED') {
+          if (response.status === 401 || errorCode === 'UNAUTHORIZED') {
             showToast({
               message: 'Please sign in to save images to your gallery',
               type: 'info',
@@ -244,7 +304,7 @@ export function useGallery(): IUseGalleryReturn {
             return false;
           }
 
-          throw new Error(data.message || data.error || 'Failed to save image');
+          throw new Error(getApiErrorMessage(data, 'Failed to save image'));
         }
 
         // Update usage stats from response (API returns { success, data, usage })
@@ -307,12 +367,16 @@ export function useGallery(): IUseGalleryReturn {
       try {
         const response = await fetch(`/api/gallery/${imageId}`, {
           method: 'DELETE',
+          headers: await getAuthHeaders(),
         });
 
-        const data = await response.json();
+        const data = (await response.json()) as ApiErrorBody & {
+          success?: boolean;
+          usage?: IGalleryStats;
+        };
 
         if (!response.ok) {
-          throw new Error(data.message || data.error || 'Failed to delete image');
+          throw new Error(getApiErrorMessage(data, 'Failed to delete image'));
         }
 
         // Remove image from local state

--- a/docs/PRDs/clarity-pro-recraft-crisp-models.md
+++ b/docs/PRDs/clarity-pro-recraft-crisp-models.md
@@ -1,0 +1,544 @@
+# PRD: Clarity Pro and Recraft Crisp Upscale Models
+
+**Version:** 1.0
+**Status:** Ready
+**Date:** May 7, 2026
+**Author:** Principal Architect
+**Complexity:** 9 -> HIGH mode
+
+---
+
+## 1. Context
+
+### Problem
+
+MyImageUpscaler needs to add two Replicate upscaling models with correct provider inputs, before/after gallery assets, and credit pricing that reflects actual provider economics instead of flat model multipliers.
+
+### Files Analyzed
+
+```
+.claude/skills/add-ai-model/SKILL.md
+.claude/skills/add-gallery-images/SKILL.md
+.claude/skills/replicate-before-after/SKILL.md
+shared/config/credits.config.ts
+shared/config/model-costs.config.ts
+shared/config/subscription.config.ts
+shared/config/subscription.utils.ts
+shared/types/coreflow.types.ts
+shared/validation/upscale.schema.ts
+server/services/model-registry.ts
+server/services/model-registry.types.ts
+server/services/providers/replicate.provider-adapter.ts
+server/services/replicate.service.ts
+server/services/replicate/builders/model-input.builder.ts
+server/services/replicate/builders/model-input.types.ts
+server/services/replicate/builders/models/clarity-upscaler.builder.ts
+server/services/image-generation.service.ts
+app/api/upscale/route.ts
+app/api/credit-estimate/route.ts
+client/components/features/workspace/ModelGalleryModal.tsx
+client/components/features/workspace/ModelCard.tsx
+client/components/features/workspace/BatchSidebar/QualityTierSelector.tsx
+client/components/features/workspace/BatchSidebar/UpscaleFactorSelector.tsx
+public/before-after/
+docs/management/regional-pricing-margin-analysis.md
+docs/PRDs/variable-credit-costs-per-model.md
+```
+
+### Current Behavior
+
+- Replicate model onboarding is split across cost config, credit config, model registry, model ID types, provider supported models, builders, validation, quality tier config, and UI gallery config.
+- Existing premium upscale credits are mostly fixed or scale-multiplier based.
+- `MODEL_SCALE_CREDIT_MULTIPLIERS` handles scale-aware pricing for old `clarity-upscaler`, but it cannot price models billed by output megapixel.
+- `creditCosts.maximumCost` currently caps premium jobs around 20 credits, which is unsafe for high-output Clarity Pro jobs.
+- Gallery before/after images already live in `public/before-after/{tier}/before.webp` and `after.webp`, with `QUALITY_TIER_CONFIG.previewImages` pointing at those files.
+
+### External Model Facts Fetched
+
+| Model | Replicate URL | Latest version | Inputs | Pricing | Example before | Example after |
+|-------|---------------|----------------|--------|---------|----------------|---------------|
+| Clarity Pro Upscaler | `https://replicate.com/philz1337x/clarity-pro-upscaler` | `8e33eb474936d75d3ceaa787f3e66f5ba16f35db0853a7697a4ca4e5fc14b6cd` | `image`, `scale_factor` enum `2/4/8/16`, `creativity` `-10..10`, `output_format` `png/jpg` | `$0.03` per output megapixel, `$0.03` minimum, 64MP output cap | `https://replicate.delivery/pbxt/P1JJHJWKqtuYlyUYLexBeYOFST6Vc2M3nGrjkpV0JLkRpn9J/flux_input.jpg` | `https://replicate.delivery/xezq/P3PaZ1wzAE7hL16eaM4Gy5Jq5l1QLqEfUuGZPtvPaLM7vcgWA/tmpyv_avm5x.png` |
+| Recraft Crisp Upscale | `https://replicate.com/recraft-ai/recraft-crisp-upscale` | `2177c1e3a177f5a76c632e467c32b413e424c23d84e43f7b036a965e305f6557` | `image` only | `$6` per 1,000 output images = `$0.006` per image | `https://replicate.delivery/pbxt/MKdkS3Po0PXytPbTXh4bOlBX1BZRuXH4o34yXVEakeBlpiTW/blonde_mj.png` | `https://replicate.delivery/czjl/MbxcznPodb6nN1hIgSVAPf9DGJOA2HvJYGxbzW4T26BYE2CKA/tmpo2nljpw_.webp` |
+
+Source pages:
+
+- `https://replicate.com/philz1337x/clarity-pro-upscaler`
+- `https://replicate.com/philz1337x/clarity-pro-upscaler/api`
+- `https://replicate.com/recraft-ai/recraft-crisp-upscale`
+- `https://replicate.com/recraft-ai/recraft-crisp-upscale/api`
+
+---
+
+## 2. Solution
+
+### Approach
+
+1. Add two new internal model IDs: `clarity-pro-upscaler` and `recraft-crisp-upscale`.
+2. Add two quality tiers:
+   - `clarity-pro`: premium pixel-priced creative/detail upscaler.
+   - `crisp-upscale`: fixed-cost sharp/clean upscale tier powered by Recraft.
+3. Extend cost calculation to support provider-cost-based dynamic credits for models where cost depends on input dimensions and scale.
+4. Add model-specific builders, registry entries, provider support, validation, and UI gallery cards.
+5. Download/convert before-after examples to `public/before-after/{tier}/before.webp` and `after.webp`.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    UI[Workspace + Model Gallery] --> Estimate[credit-estimate API]
+    UI --> Upscale[upscale API]
+    Estimate --> Pricing[model-costs/subscription utils]
+    Upscale --> Pricing
+    Upscale --> Registry[ModelRegistry]
+    Registry --> ReplicateService
+    ReplicateService --> Builders[Model Input Builders]
+    Builders --> Replicate[Replicate API]
+    Replicate --> Parser[Output Parser]
+```
+
+### Integration Points Checklist
+
+**How will this feature be reached?**
+
+- [x] Entry point identified: Model Gallery tier selection in workspace, then `/api/credit-estimate` and `/api/upscale`.
+- [x] Caller file identified: `client/components/features/workspace/BatchSidebar.tsx` and subcomponents drive tier/scale selection; `app/api/upscale/route.ts` invokes `ReplicateService`.
+- [x] Registration/wiring needed: model registry, Replicate provider supported models, builder orchestrator, quality tier config, validation enum, credit estimate route, gallery assets.
+
+**Is this user-facing?**
+
+- [x] YES -> UI components required: Model Gallery cards, tier selector cost display, scale selector behavior, credit estimate display, insufficient-credit messaging.
+
+**Full user flow:**
+
+1. User opens Model Gallery and selects `Clarity Pro` or `Crisp Upscale`.
+2. UI updates available scale controls:
+   - `clarity-pro`: show 2x/4x/8x for launch.
+   - `crisp-upscale`: hide scale controls because the Replicate model has no scale parameter.
+3. UI calls `/api/credit-estimate`.
+4. API calculates fixed credits for Recraft or dynamic pixel-aware credits for Clarity Pro.
+5. User clicks upscale.
+6. `/api/upscale` validates model access, charges credits, calls Replicate with the correct input schema, and returns the output URL.
+7. Result appears in workspace; analytics records model, credits, scale, estimated provider cost.
+
+### Key Decisions
+
+- **Clarity Pro must be dynamic-priced.** Its provider cost is `max($0.03, outputMP * $0.03)`, so fixed multipliers would either overcharge small images or lose money on large images.
+- **Use `$0.005 provider cost per credit` as the pricing target.** This matches the existing base-case economics doc and preserves margin even in discounted regions better than a `$0.010` ceiling-only approach.
+- **Recraft Crisp should be 2 credits.** Provider cost is `$0.006/image`; 2 credits yields `$0.003` provider cost per credit and fits existing premium-but-affordable model pricing.
+- **Clarity Pro launch supports 2x/4x/8x only.** The model supports 16x, but the product schema and UI currently support 2/4/8. Exposing 16x should be a separate follow-up after UX and affordability messaging are designed.
+- **Recraft Crisp needs fixed-scale metadata, not user scale support.** The model input has only `image`; add `fixedOutputScale: 4` or equivalent metadata for output-dimension reporting while keeping `supportedScales: []` so the UI does not show a fake selector.
+
+### Economics
+
+Current standard revenue per credit:
+
+| Source | Revenue per credit |
+|--------|--------------------|
+| Starter subscription | `$0.0900` |
+| Hobby subscription | `$0.0950` |
+| Pro subscription | `$0.0490` |
+| Business subscription | `$0.0298` |
+| Small credit pack | `$0.0998` |
+| Medium credit pack | `$0.0750` |
+| Large credit pack | `$0.0667` |
+| Lowest documented regional Business | `$0.0104` |
+
+Credit conversion rules:
+
+```ts
+const PROVIDER_COST_PER_CREDIT_TARGET_USD = 0.005;
+
+// Clarity Pro
+outputMegapixels = min((inputWidth * scale * inputHeight * scale) / 1_000_000, 64);
+providerCostUsd = max(0.03, outputMegapixels * 0.03);
+credits = ceil(providerCostUsd / PROVIDER_COST_PER_CREDIT_TARGET_USD);
+
+// Recraft Crisp
+providerCostUsd = 0.006;
+credits = 2;
+```
+
+Clarity Pro examples:
+
+| Input -> Scale | Output MP | Provider cost | Credits | Provider cost / credit |
+|----------------|-----------|---------------|---------|------------------------|
+| Any tiny output under 1MP | `<1MP` | `$0.03` minimum | `6` | `$0.0050` |
+| 0.25MP input at 2x | `1MP` | `$0.03` | `6` | `$0.0050` |
+| 1MP input at 2x | `4MP` | `$0.12` | `24` | `$0.0050` |
+| 1MP input at 4x | `16MP` | `$0.48` | `96` | `$0.0050` |
+| 1MP input at 8x | `64MP` capped | `$1.92` | `384` | `$0.0050` |
+
+Risk note: existing `maximumCost` around 20 credits would cap a 16MP Clarity Pro job at 20 credits while provider cost is `$0.48`, or `$0.024/credit`. Phase 2 must bypass or replace that global cap for pixel-priced models.
+
+### Data Changes
+
+No database migration required. Credit transaction RPCs already accept variable credit amounts.
+
+---
+
+## 3. Sequence Flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Workspace UI
+    participant CE as /api/credit-estimate
+    participant UP as /api/upscale
+    participant PR as Pricing Helper
+    participant RS as ReplicateService
+    participant RP as Replicate
+
+    UI->>CE: POST tier=clarity-pro, scale=4, inputDimensions=1000x1000
+    CE->>PR: calculateProviderAwareCredits(model, dimensions, scale)
+    PR-->>CE: providerCost=$0.48, credits=96
+    CE-->>UI: totalCredits=96
+    UI->>UP: POST upscale request
+    UP->>PR: calculateProviderAwareCredits(...)
+    PR-->>UP: credits=96
+    UP->>UP: deductCredits(userId, 96)
+    UP->>RS: processImage(model=clarity-pro-upscaler)
+    RS->>RP: { image, scale_factor: 4, creativity: 0, output_format: "png" }
+    RP-->>RS: output URL
+    RS-->>UP: parsed image result
+    UP-->>UI: imageUrl, creditsUsed=96
+```
+
+---
+
+## 4. Execution Phases
+
+### Phase 1: Model Registry and Builders - "The server can construct valid Replicate inputs for both models"
+
+**Files (5):**
+
+- `shared/config/model-costs.config.ts` - add model cost constants, pixel-priced metadata, max input/output limits, tier arrays, `MODEL_CONFIG` entries.
+- `shared/config/credits.config.ts` - add fixed Recraft multiplier and dynamic Clarity Pro credit constant metadata.
+- `server/services/model-registry.types.ts` - add model IDs and optional `fixedOutputScale` / `pricingModel` fields.
+- `server/services/model-registry.ts` - add default versions, cost maps, multiplier maps, registry entries.
+- `server/services/replicate/builders/models/*.ts` plus `index.ts` / orchestrator registration - add `ClarityProUpscalerBuilder` and `RecraftCrispUpscaleBuilder`.
+
+**Implementation:**
+
+- [ ] Add model IDs:
+  - `clarity-pro-upscaler`
+  - `recraft-crisp-upscale`
+- [ ] Add latest model versions:
+  - `philz1337x/clarity-pro-upscaler`
+  - `recraft-ai/recraft-crisp-upscale`
+- [ ] Add Clarity Pro config:
+  - `cost: 0.03` as minimum metadata.
+  - `pricingModel: 'output-megapixel'`.
+  - `outputMegapixelPriceUsd: 0.03`.
+  - `minimumProviderCostUsd: 0.03`.
+  - `maxOutputMegapixels: 64`.
+  - `supportedScales: [2, 4, 8]` for launch.
+  - `tierRestriction: 'hobby'` or stricter `pro` if product wants to reserve high-cost jobs.
+- [ ] Add Recraft config:
+  - `cost: 0.006`.
+  - `pricingModel: 'per-image'`.
+  - `fixedOutputScale: 4`.
+  - `supportedScales: []`.
+  - `capabilities: ['enhance', 'denoise', '4k-output']` plus product-specific metadata; do not expose fake scale controls.
+- [ ] Clarity builder input:
+  ```ts
+  {
+    image: imageDataUrl,
+    scale_factor: context.scale,
+    creativity: 0,
+    output_format: 'png',
+  }
+  ```
+- [ ] Recraft builder input:
+  ```ts
+  {
+    image: imageDataUrl,
+  }
+  ```
+
+**Tests Required:**
+
+| Test File | Test Name | Assertion |
+|-----------|-----------|-----------|
+| `tests/unit/server/model-registry-new-upscalers.unit.spec.ts` | `registers clarity-pro-upscaler with versionless Replicate model` | registry returns model with `modelVersion === 'philz1337x/clarity-pro-upscaler'` |
+| `tests/unit/server/model-registry-new-upscalers.unit.spec.ts` | `registers recraft-crisp-upscale as fixed-scale image-only model` | model has `supportedScales: []` and `fixedOutputScale: 4` |
+| `server/services/__tests__/replicate.service.test.ts` | `builds Clarity Pro input schema` | input contains `image`, `scale_factor`, `creativity`, `output_format` |
+| `server/services/__tests__/replicate.service.test.ts` | `builds Recraft Crisp input schema` | input contains only supported `image` field |
+
+**User Verification:**
+
+- Action: Run builder tests for both model IDs.
+- Expected: No `No builder registered for model` errors and input keys match Replicate schemas.
+
+### Phase 2: Pixel-Aware Credit Pricing - "Credit estimates and deductions protect margins for output-megapixel pricing"
+
+**Files (5):**
+
+- `shared/config/model-costs.config.ts` - export provider pricing metadata and helper constants.
+- `shared/config/subscription.utils.ts` - add provider-aware credit calculation helper.
+- `server/services/image-generation.service.ts` - use helper for service-side cost calculations.
+- `app/api/credit-estimate/route.ts` - return dynamic Clarity Pro credits using input dimensions.
+- `app/api/upscale/route.ts` - deduct the same dynamic credits as estimate route.
+
+**Implementation:**
+
+- [ ] Add reusable helper:
+  ```ts
+  calculateProviderAwareCredits({
+    modelId,
+    qualityTier,
+    scale,
+    inputWidth,
+    inputHeight,
+    smartAnalysis,
+  }): {
+    credits: number;
+    providerCostUsd: number;
+    outputMegapixels?: number;
+    pricingModel: 'flat' | 'per-image' | 'output-megapixel';
+  }
+  ```
+- [ ] For Clarity Pro, compute provider cost from output megapixels and cap at 64MP.
+- [ ] For Recraft Crisp, return 2 credits and `$0.006` provider cost.
+- [ ] Replace or bypass `maximumCost` for `pricingModel: 'output-megapixel'`; use a model-specific cap such as 384 launch credits, derived from the 64MP provider cap.
+- [ ] Ensure estimate route and upscale route call the same helper to prevent estimate/deduction drift.
+- [ ] Return `providerCostUsd` only in server logs/analytics; do not expose internal cost to normal clients unless behind debug/admin.
+- [ ] Add insufficient-credit messaging for dynamic jobs that require more credits than the user has.
+
+**Tests Required:**
+
+| Test File | Test Name | Assertion |
+|-----------|-----------|-----------|
+| `tests/unit/config/provider-aware-credits.unit.spec.ts` | `charges 6 credits for Clarity Pro minimum cost` | tiny output returns `credits: 6` |
+| `tests/unit/config/provider-aware-credits.unit.spec.ts` | `charges 96 credits for Clarity Pro 1MP at 4x` | 1000x1000 at 4x returns `providerCostUsd: 0.48`, `credits: 96` |
+| `tests/unit/config/provider-aware-credits.unit.spec.ts` | `caps Clarity Pro output cost at 64MP` | huge input at 8x returns `credits: 384` |
+| `tests/unit/config/provider-aware-credits.unit.spec.ts` | `charges 2 credits for Recraft Crisp` | any dimensions returns `credits: 2` |
+| `tests/unit/api/credit-estimate-new-upscalers.unit.spec.ts` | `estimate matches upscale route helper` | both paths return identical total credits |
+
+**User Verification:**
+
+- Action: Estimate `clarity-pro` for 1000x1000 at 4x.
+- Expected: UI/API shows 96 credits, not the old 20-credit cap.
+
+### Phase 3: Quality Tiers, Validation, and UI Wiring - "Users can select both models and see accurate controls/costs"
+
+**Files (5):**
+
+- `shared/types/coreflow.types.ts` - add `clarity-pro` and `crisp-upscale` tiers, model IDs, scales, preview image paths.
+- `shared/validation/upscale.schema.ts` - add new quality tiers and model IDs to Zod enums.
+- `server/services/providers/replicate.provider-adapter.ts` - add supported models.
+- `client/components/features/workspace/BatchSidebar/QualityTierSelector.tsx` - display dynamic credits or use estimate for Clarity Pro.
+- `client/components/features/workspace/BatchSidebar/UpscaleFactorSelector.tsx` - ensure empty scale list hides selector for Recraft and scale list shows 2/4/8 for Clarity Pro.
+
+**Implementation:**
+
+- [ ] Add quality tier union members:
+  - `clarity-pro`
+  - `crisp-upscale`
+- [ ] Add `QUALITY_TIER_CONFIG` entries:
+  ```ts
+  'clarity-pro': {
+    label: 'Clarity Pro',
+    credits: 'variable',
+    modelId: 'clarity-pro-upscaler',
+    description: 'Creative high-detail upscale',
+    bestFor: 'Portraits, products, AI images, print',
+    smartAnalysisAlwaysOn: false,
+    useCases: ['creative upscale', 'identity', 'print', 'portrait', 'product'],
+    previewImages: {
+      before: '/before-after/clarity-pro/before.webp',
+      after: '/before-after/clarity-pro/after.webp',
+    },
+    badge: 'popular',
+    popularity: 80,
+  }
+  ```
+  ```ts
+  'crisp-upscale': {
+    label: 'Crisp Upscale',
+    credits: 2,
+    modelId: 'recraft-crisp-upscale',
+    description: 'Sharper, cleaner images',
+    bestFor: 'Web graphics, product shots, print-ready assets',
+    smartAnalysisAlwaysOn: false,
+    useCases: ['crisp', 'sharp', 'clean', 'web', 'print'],
+    previewImages: {
+      before: '/before-after/crisp-upscale/before.webp',
+      after: '/before-after/crisp-upscale/after.webp',
+    },
+    popularity: 70,
+  }
+  ```
+- [ ] Add `QUALITY_TIER_SCALES`:
+  - `clarity-pro: [2, 4, 8]`
+  - `crisp-upscale: []`
+- [ ] Add both tiers to `PREMIUM_QUALITY_TIERS`.
+- [ ] Ensure free users see locked cards with existing upgrade flow.
+- [ ] Ensure user changing from `clarity-pro` to `crisp-upscale` does not leave stale 8x scale assumptions in estimate/deduction.
+
+**Tests Required:**
+
+| Test File | Test Name | Assertion |
+|-----------|-----------|-----------|
+| `tests/unit/shared/quality-tier-config.unit.spec.ts` | `includes clarity-pro tier with variable credits` | config has model ID and preview paths |
+| `tests/unit/shared/quality-tier-config.unit.spec.ts` | `includes crisp-upscale tier with fixed 2 credits` | config has no scales and 2 credits |
+| `tests/unit/client/components/ModelGalleryModal.new-upscalers.unit.spec.tsx` | `renders both new premium model cards` | labels visible and locked for free users |
+| `tests/unit/client/components/UpscaleFactorSelector.new-upscalers.unit.spec.tsx` | `hides scale controls for crisp-upscale` | no scale buttons rendered |
+
+**User Verification:**
+
+- Action: Open Model Gallery as a paid user.
+- Expected: `Clarity Pro` and `Crisp Upscale` appear with images and selectable cards.
+
+### Phase 4: Gallery Assets - "Model Gallery shows real before/after previews for both new tiers"
+
+**Files (4):**
+
+- `public/before-after/clarity-pro/before.webp` - converted from fetched Replicate example.
+- `public/before-after/clarity-pro/after.webp` - converted from fetched Replicate example.
+- `public/before-after/crisp-upscale/before.webp` - converted from fetched Replicate example.
+- `public/before-after/crisp-upscale/after.webp` - converted from fetched Replicate example.
+
+**Implementation:**
+
+- [ ] Use the existing scraper:
+  ```bash
+  npx tsx .claude/skills/replicate-before-after/scripts/scrape-replicate-examples.ts \
+    https://replicate.com/philz1337x/clarity-pro-upscaler \
+    clarity-pro \
+    0 \
+    512
+  ```
+- [ ] Use the existing scraper:
+  ```bash
+  npx tsx .claude/skills/replicate-before-after/scripts/scrape-replicate-examples.ts \
+    https://replicate.com/recraft-ai/recraft-crisp-upscale \
+    crisp-upscale \
+    0 \
+    512
+  ```
+- [ ] If scraper fails, use the direct fetched URLs from this PRD with `.claude/skills/add-gallery-images/scripts/add-gallery-images.sh` after downloading source files.
+- [ ] Verify final images are 512x512 WebP and visually show meaningful differences.
+
+**Tests Required:**
+
+| Test File | Test Name | Assertion |
+|-----------|-----------|-----------|
+| `tests/unit/shared/quality-tier-config.unit.spec.ts` | `new preview image paths exist` | `fs.existsSync(public path)` true |
+| `tests/e2e/model-gallery-new-upscalers.e2e.spec.ts` | `loads new before/after images` | images return 200 and render in modal |
+
+**User Verification:**
+
+- Action: Open Model Gallery and inspect both cards.
+- Expected: Both cards display real before/after images with no placeholder gradient.
+
+### Phase 5: End-to-End Provider Verification and Rollout - "Both models can run safely in production"
+
+**Files (5):**
+
+- `tests/api/multi-model.api.spec.ts` - add model availability and access assertions.
+- `tests/integration/multi-model-workflow.integration.spec.ts` - add workflow coverage for both tiers.
+- `tests/e2e/model-gallery-new-upscalers.e2e.spec.ts` - add UI smoke coverage.
+- `docs/business-model-canvas/economics/image-upscaling-models.md` - document new provider costs and credit rules.
+- `docs/management/regional-pricing-margin-analysis.md` - update model mix assumptions for pixel-priced jobs.
+
+**Implementation:**
+
+- [ ] Add API tests for:
+  - Free user blocked from both premium tiers.
+  - Paid user can estimate both tiers.
+  - Recraft fixed-cost estimate returns 2 credits.
+  - Clarity Pro dynamic estimate varies with dimensions and scale.
+- [ ] Add one manual live Replicate smoke test behind an env guard:
+  - `RUN_REPLICATE_LIVE_TESTS=1 yarn test:api --grep "new upscalers live"`
+- [ ] Track analytics fields:
+  - `modelUsed`
+  - `qualityTier`
+  - `creditsUsed`
+  - `estimatedProviderCostUsd`
+  - `outputMegapixels`
+  - `pricingModel`
+- [ ] Update economics docs with the final conversion formula.
+- [ ] Add rollout flag option if desired:
+  - `ENABLE_CLARITY_PRO_UPSCALER`
+  - `ENABLE_RECRAFT_CRISP_UPSCALE`
+
+**Tests Required:**
+
+| Test File | Test Name | Assertion |
+|-----------|-----------|-----------|
+| `tests/api/multi-model.api.spec.ts` | `free users cannot access clarity-pro or crisp-upscale` | API returns upgrade/authorization error |
+| `tests/api/multi-model.api.spec.ts` | `paid users can estimate new model costs` | API returns valid credits |
+| `tests/integration/multi-model-workflow.integration.spec.ts` | `processes recraft crisp workflow` | request reaches `recraft-crisp-upscale` |
+| `tests/integration/multi-model-workflow.integration.spec.ts` | `processes clarity pro workflow with dynamic credits` | credits deducted equal helper result |
+
+**User Verification:**
+
+- Action: Run one paid-user smoke job for each tier in staging.
+- Expected: Recraft returns a crisp 4x-style output for 2 credits; Clarity Pro returns an output and deducts dynamic credits from the estimate.
+
+---
+
+## 5. Checkpoint Protocol
+
+Because this is HIGH complexity, each phase requires automated review and manual checks where external provider or UI behavior is involved.
+
+After each phase:
+
+1. Run the phase-specific tests.
+2. Run `yarn tsc`.
+3. Run targeted lint/format for touched files.
+4. Spawn/check with a PRD reviewer equivalent:
+   - Review implementation against `docs/PRDs/clarity-pro-recraft-crisp-models.md`.
+   - Confirm files changed match the phase scope.
+   - Confirm estimate and deduction logic are identical.
+
+Manual checkpoints required for:
+
+- Phase 3 UI behavior.
+- Phase 4 gallery images.
+- Phase 5 live Replicate smoke tests.
+
+---
+
+## 6. Verification Strategy
+
+### Automated
+
+- Unit tests for provider-aware credits.
+- Unit tests for model registry metadata.
+- Unit tests for Replicate input builders.
+- API tests for estimate/access behavior.
+- E2E smoke test for gallery rendering.
+
+### Manual
+
+- Verify actual Replicate model pages still show the fetched pricing before implementation starts.
+- Run a tiny Clarity Pro job and compare charged credits to output megapixels from Replicate metrics.
+- Run a Recraft Crisp job and confirm no unsupported scale field is sent.
+- Inspect gallery card crops for both tiers.
+
+### Rollback
+
+- Disable new tiers by removing them from `PREMIUM_QUALITY_TIERS` or feature-gating registry `isEnabled`.
+- Keep builders and config in place for later re-enable.
+- If Clarity Pro costs drift, update only provider pricing metadata and tests.
+
+---
+
+## 7. Open Questions
+
+1. Should `clarity-pro` require Hobby like other premium models, or Pro because single jobs can cost 96-384 credits?
+2. Should Clarity Pro expose `creativity` as an advanced control later, or keep `0` for predictable identity preservation at launch?
+3. Should 16x be a separate future tier because it requires expanding product scale types and more aggressive affordability messaging?
+
+---
+
+## 8. Definition of Done
+
+- Both model IDs are registered and have Replicate builders.
+- Both quality tiers render in the Model Gallery with real before/after images.
+- Recraft Crisp always estimates and deducts 2 credits.
+- Clarity Pro estimates and deducts pixel-aware dynamic credits using the same helper in estimate and execution paths.
+- Clarity Pro cannot be clipped by the old global maximum credit cap.
+- Free users are blocked from premium tiers; paid users can use them.
+- Tests prove pricing, builder inputs, validation, and UI availability.
+- Economics docs include the new provider pricing and credit conversion rules.

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -58,6 +58,7 @@
   },
   "nav": {
     "dashboard": "Armaturenbrett",
+    "gallery": "Galerie",
     "features": "Funktionen",
     "howItWorks": "Wie es funktioniert",
     "pricing": "Preise",

--- a/locales/de/workspace.json
+++ b/locales/de/workspace.json
@@ -148,6 +148,10 @@
   "imageComparison": {
     "enhanced": "Verbessert",
     "toggleZoom": "Zoom umschalten",
+    "saveToGallery": "In Galerie speichern",
+    "save": "Speichern",
+    "savedToGallery": "In Galerie gespeichert",
+    "saved": "Gespeichert",
     "downloadResult": "Ergebnis herunterladen",
     "download": "Herunterladen",
     "original": "Original",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -112,6 +112,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "gallery": "Gallery",
     "features": "Features",
     "howItWorks": "How it Works",
     "pricing": "Pricing",

--- a/locales/en/workspace.json
+++ b/locales/en/workspace.json
@@ -162,6 +162,10 @@
   "imageComparison": {
     "enhanced": "Enhanced",
     "toggleZoom": "Toggle Zoom",
+    "saveToGallery": "Save to Gallery",
+    "save": "Save",
+    "savedToGallery": "Saved to Gallery",
+    "saved": "Saved",
     "downloadResult": "Download Result",
     "download": "Download",
     "original": "Original",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -58,6 +58,7 @@
   },
   "nav": {
     "dashboard": "Panel",
+    "gallery": "Galería",
     "features": "Características",
     "howItWorks": "Cómo Funciona",
     "pricing": "Precios",

--- a/locales/es/workspace.json
+++ b/locales/es/workspace.json
@@ -148,6 +148,10 @@
   "imageComparison": {
     "enhanced": "Mejorado",
     "toggleZoom": "Alternar zoom",
+    "saveToGallery": "Guardar en galería",
+    "save": "Guardar",
+    "savedToGallery": "Guardado en galería",
+    "saved": "Guardado",
     "downloadResult": "Descargar resultado",
     "download": "Descargar",
     "original": "Original",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -50,6 +50,7 @@
     "login": "Connexion",
     "signup": "S'inscrire",
     "dashboard": "Tableau de bord",
+    "gallery": "Galerie",
     "logout": "Déconnexion",
     "features": "Fonctionnalités",
     "howItWorks": "Comment ça marche",

--- a/locales/fr/workspace.json
+++ b/locales/fr/workspace.json
@@ -148,6 +148,10 @@
   "imageComparison": {
     "enhanced": "Amélioré",
     "toggleZoom": "Basculer le zoom",
+    "saveToGallery": "Enregistrer dans la galerie",
+    "save": "Enregistrer",
+    "savedToGallery": "Enregistré dans la galerie",
+    "saved": "Enregistré",
     "downloadResult": "Télécharger le résultat",
     "download": "Télécharger",
     "original": "Original",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -58,6 +58,7 @@
   },
   "nav": {
     "dashboard": "Pannello di controllo",
+    "gallery": "Galleria",
     "features": "Funzionalità",
     "howItWorks": "Come Funziona",
     "pricing": "Prezzi",

--- a/locales/it/workspace.json
+++ b/locales/it/workspace.json
@@ -148,6 +148,10 @@
   "imageComparison": {
     "enhanced": "Migliorato",
     "toggleZoom": "Alterna Zoom",
+    "saveToGallery": "Salva in galleria",
+    "save": "Salva",
+    "savedToGallery": "Salvato in galleria",
+    "saved": "Salvato",
     "downloadResult": "Scarica Risultato",
     "download": "Scarica",
     "original": "Originale",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -58,6 +58,7 @@
   },
   "nav": {
     "dashboard": "ダッシュボード",
+    "gallery": "ギャラリー",
     "features": "機能",
     "howItWorks": "仕組み",
     "pricing": "料金",

--- a/locales/ja/workspace.json
+++ b/locales/ja/workspace.json
@@ -148,6 +148,10 @@
   "imageComparison": {
     "enhanced": "強化済み",
     "toggleZoom": "ズームの切り替え",
+    "saveToGallery": "ギャラリーに保存",
+    "save": "保存",
+    "savedToGallery": "ギャラリーに保存済み",
+    "saved": "保存済み",
     "downloadResult": "結果をダウンロード",
     "download": "ダウンロード",
     "original": "オリジナル",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -58,6 +58,7 @@
   },
   "nav": {
     "dashboard": "Painel",
+    "gallery": "Galeria",
     "features": "Recursos",
     "howItWorks": "Como Funciona",
     "pricing": "Preços",

--- a/locales/pt/workspace.json
+++ b/locales/pt/workspace.json
@@ -148,6 +148,10 @@
   "imageComparison": {
     "enhanced": "Melhorada",
     "toggleZoom": "Alternar Zoom",
+    "saveToGallery": "Salvar na galeria",
+    "save": "Salvar",
+    "savedToGallery": "Salvo na galeria",
+    "saved": "Salvo",
     "downloadResult": "Baixar Resultado",
     "download": "Baixar",
     "original": "Original",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "test:billing": "playwright test --project=integration --grep 'proof'",
     "test:billing:e2e": "playwright test --project=chromium tests/e2e/*-proof.e2e.spec.ts",
     "test:smoke": "playwright test --config=playwright.smoke.config.ts",
+    "cron:check": "node scripts/check-cron-setup.mjs",
+    "cron:test": "npm test --prefix workers/cron",
     "stripe:listen": "bash -c 'source ./scripts/load-env.sh && PORT=${PORT:-${NEXT_DEV_PORT:-3000}} && stripe listen --api-key $STRIPE_SECRET_KEY --forward-to localhost:$PORT/api/webhooks/stripe'",
     "stripe:setup": "bash -c 'source ./scripts/load-env.sh && npx tsx scripts/setup-stripe.ts'",
     "stripe:setup:test": "bash -c 'source ./scripts/load-env.sh && npx tsx scripts/setup-stripe.ts --test'",

--- a/scripts/check-cron-setup.mjs
+++ b/scripts/check-cron-setup.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const checkRemote = process.argv.includes('--remote');
+const cronDir = path.join(root, 'workers', 'cron');
+const wranglerPath = path.join(cronDir, 'wrangler.toml');
+const workerPath = path.join(cronDir, 'index.ts');
+const triggerPath = path.join(cronDir, 'scripts', 'test-trigger.js');
+
+const fail = (message) => {
+  console.error(`ERROR: ${message}`);
+  process.exitCode = 1;
+};
+
+const read = (filePath) => fs.readFileSync(filePath, 'utf8');
+
+const parseWranglerCrons = (toml) => {
+  const match = toml.match(/crons\s*=\s*\[([\s\S]*?)\]/);
+  if (!match) return [];
+
+  return [...match[1].matchAll(/"([^"]+)"/g)].map(([, cron]) => cron);
+};
+
+const parseWorkerName = (toml) => {
+  const match = toml.match(/^name\s*=\s*"([^"]+)"/m);
+  return match?.[1] ?? '';
+};
+
+const parseWorkerRoutes = (source) => {
+  const routes = new Map();
+  const routeRegex =
+    /cronPattern\s*===\s*'([^']+)'[\s\S]*?endpoint\s*=\s*'([^']+)'[\s\S]*?jobName\s*=\s*'([^']+)'/g;
+
+  for (const [, cron, endpoint, jobName] of source.matchAll(routeRegex)) {
+    routes.set(cron, { endpoint, jobName });
+  }
+
+  return routes;
+};
+
+const parseManualTriggerJobs = (source) => {
+  const match = source.match(/const JOBS\s*=\s*\{([\s\S]*?)\};/);
+  if (!match) return new Map();
+
+  const jobs = new Map();
+  const jobRegex = /['"]?([a-zA-Z0-9_-]+)['"]?\s*:\s*'([^']+)'/g;
+  for (const [, name, cron] of match[1].matchAll(jobRegex)) {
+    jobs.set(cron, name);
+  }
+
+  return jobs;
+};
+
+const assertUnique = (items, label) => {
+  const seen = new Set();
+  for (const item of items) {
+    if (seen.has(item)) fail(`Duplicate ${label}: ${item}`);
+    seen.add(item);
+  }
+};
+
+const wranglerConfig = read(wranglerPath);
+const cronPatterns = parseWranglerCrons(wranglerConfig);
+const cronWorkerName = parseWorkerName(wranglerConfig);
+const workerRoutes = parseWorkerRoutes(read(workerPath));
+const manualJobs = parseManualTriggerJobs(read(triggerPath));
+
+assertUnique(cronPatterns, 'cron pattern in workers/cron/wrangler.toml');
+assertUnique([...workerRoutes.keys()], 'cron pattern in workers/cron/index.ts');
+assertUnique([...workerRoutes.values()].map(({ endpoint }) => endpoint), 'cron endpoint in workers/cron/index.ts');
+
+for (const cron of cronPatterns) {
+  const route = workerRoutes.get(cron);
+  if (!route) {
+    fail(`Cron pattern ${cron} is configured in wrangler.toml but not routed in workers/cron/index.ts`);
+    continue;
+  }
+
+  const endpointRoutePath = path.join(root, 'app', route.endpoint.replace(/^\//, ''), 'route.ts');
+  if (!fs.existsSync(endpointRoutePath)) {
+    fail(`Cron pattern ${cron} routes to ${route.endpoint}, but ${endpointRoutePath} does not exist`);
+    continue;
+  }
+
+  const endpointSource = read(endpointRoutePath);
+  if (!endpointSource.includes("request.headers.get('x-cron-secret')")) {
+    fail(`${route.endpoint} does not validate the x-cron-secret request header`);
+  }
+
+  if (!endpointSource.includes('serverEnv.CRON_SECRET')) {
+    fail(`${route.endpoint} does not compare against serverEnv.CRON_SECRET`);
+  }
+
+  if (!manualJobs.has(cron)) {
+    fail(`Cron pattern ${cron} (${route.jobName}) is missing from workers/cron/scripts/test-trigger.js`);
+  }
+}
+
+for (const [cron, route] of workerRoutes.entries()) {
+  if (!cronPatterns.includes(cron)) {
+    fail(`Cron pattern ${cron} routes to ${route.endpoint}, but is missing from workers/cron/wrangler.toml`);
+  }
+}
+
+if (!cronWorkerName) {
+  fail('workers/cron/wrangler.toml is missing a top-level worker name');
+}
+
+const assertRemoteSchedules = async () => {
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+
+  if (!apiToken || !accountId) {
+    fail('CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required for --remote cron checks');
+    return;
+  }
+
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${cronWorkerName}/schedules`,
+    {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    fail(`Cloudflare schedule lookup failed for ${cronWorkerName}: HTTP ${response.status} ${body}`);
+    return;
+  }
+
+  const payload = await response.json();
+  if (payload.success === false) {
+    fail(`Cloudflare schedule lookup failed for ${cronWorkerName}: ${JSON.stringify(payload.errors)}`);
+    return;
+  }
+
+  const result = payload.result?.schedules ?? payload.result ?? [];
+  const remoteSchedules = result
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      return item.cron ?? item.pattern ?? item.schedule;
+    })
+    .filter(Boolean);
+
+  assertUnique(remoteSchedules, `deployed Cloudflare schedule on ${cronWorkerName}`);
+
+  for (const cron of cronPatterns) {
+    if (!remoteSchedules.includes(cron)) {
+      fail(`Cloudflare worker ${cronWorkerName} is missing active cron schedule: ${cron}`);
+    }
+  }
+
+  for (const cron of remoteSchedules) {
+    if (!cronPatterns.includes(cron)) {
+      fail(`Cloudflare worker ${cronWorkerName} has unexpected active cron schedule: ${cron}`);
+    }
+  }
+};
+
+if (checkRemote) {
+  await assertRemoteSchedules();
+}
+
+if (!process.exitCode) {
+  const scope = checkRemote ? 'local and deployed cron setup' : 'cron setup';
+  console.log(`OK: ${scope} valid (${cronPatterns.length} jobs)`);
+}

--- a/scripts/deploy/steps/01-preflight.sh
+++ b/scripts/deploy/steps/01-preflight.sh
@@ -31,6 +31,9 @@ step_preflight() {
     # Webhook endpoint must subscribe to all required event types
     _check_stripe_webhook_events
 
+    # Cron worker config must stay in sync with router, endpoints, and manual triggers
+    _check_cron_setup
+
     # Stripe products check (informational only)
     check_stripe_products
 }
@@ -176,6 +179,21 @@ for ep in data.get('data', []):
     fi
 
     log_success "Webhook event subscriptions complete"
+}
+
+_check_cron_setup() {
+    log_info "Checking cron worker setup..."
+
+    cd "$PROJECT_ROOT"
+    if ! yarn cron:check; then
+        log_error "Cron worker setup is inconsistent"
+    fi
+
+    if [[ -z "${CRON_SECRET:-}" ]]; then
+        log_error "CRON_SECRET is not set"
+    fi
+
+    log_success "Cron worker setup valid"
 }
 
 check_stripe_products() {

--- a/scripts/deploy/steps/05-secrets.sh
+++ b/scripts/deploy/steps/05-secrets.sh
@@ -3,7 +3,7 @@
 step_secrets() {
     log_step 5 "Uploading secrets"
 
-    local worker="${WORKER_NAME:-myimageupscaler.com}"
+    local worker="${WORKER_NAME:-myimageupscaler}"
     local skip_secrets="${SKIP_SECRETS:-false}"
 
     # Get existing secrets (only needed when skipping)

--- a/scripts/deploy/steps/06-verify.sh
+++ b/scripts/deploy/steps/06-verify.sh
@@ -8,6 +8,8 @@ step_verify() {
     log_info "Waiting for propagation..."
     sleep 5
 
+    _verify_cron_schedules
+
     for i in {1..5}; do
         status=$(curl -s -o /dev/null -w "%{http_code}" "$url/api/health" 2>/dev/null || echo "000")
         if [[ "$status" == "200" ]]; then
@@ -22,6 +24,22 @@ step_verify() {
     done
 
     log_warn "Health check didn't return 200 (may still be propagating)"
+}
+
+_verify_cron_schedules() {
+    log_info "Verifying deployed cron schedules..."
+
+    cd "$PROJECT_ROOT"
+    for i in {1..5}; do
+        if yarn cron:check --remote; then
+            log_success "Cron schedules active"
+            return 0
+        fi
+        log_info "Cron schedule check attempt $i/5 failed; retrying..."
+        sleep 3
+    done
+
+    log_error "Deployed cron schedules do not match workers/cron/wrangler.toml"
 }
 
 # Verify STRIPE_WEBHOOK_SECRET on Cloudflare matches Stripe by sending a correctly-signed

--- a/server/analytics/types.ts
+++ b/server/analytics/types.ts
@@ -627,6 +627,8 @@ export type IAnalyticsEventName =
   | 'engagement_discount_eligible'
   | 'engagement_discount_toast_shown'
   | 'engagement_discount_toast_dismissed'
+  | 'engagement_discount_offer_shown'
+  | 'engagement_discount_offer_dismissed'
   | 'engagement_discount_cta_clicked'
   | 'engagement_discount_checkout_started'
   | 'engagement_discount_redeemed'

--- a/server/services/galleryStorage.service.ts
+++ b/server/services/galleryStorage.service.ts
@@ -3,7 +3,6 @@
  * Handles saving, listing, and deleting User Gallery Images
  */
 
-import sharp from 'sharp';
 import { randomUUID } from 'crypto';
 import { supabaseAdmin } from '../supabase/supabaseAdmin';
 import {
@@ -27,20 +26,19 @@ import type { ProcessingMode } from '@shared/config/subscription.types';
 const BUCKET_NAME = GALLERY_STORAGE_CONFIG.bucketName;
 
 /**
- * Compression settings for gallery images
- * Max dimension: 2048px (fit inside, no enlargement)
- * Format: WebP quality 80
- */
-const COMPRESSION_CONFIG = {
-  maxDimension: 2048,
-  quality: 80,
-  format: 'webp' as const,
-};
-
-/**
  * Signed URL expiration time in seconds (1 hour)
  */
 const SIGNED_URL_EXPIRES_IN = 3600;
+
+type GalleryImageMimeType = (typeof GALLERY_STORAGE_CONFIG.allowedMimeTypes)[number];
+
+interface IPreparedGalleryImage {
+  buffer: Buffer;
+  contentType: GalleryImageMimeType;
+  extension: string;
+  width: number;
+  height: number;
+}
 
 // =============================================================================
 // Types
@@ -149,13 +147,9 @@ export async function saveImage(
 
   // 5. Validate content-type (MIME check)
   const contentType = response.headers.get('content-type');
-  if (contentType) {
-    const mime = contentType.split(';')[0].trim().toLowerCase();
-    if (
-      !GALLERY_STORAGE_CONFIG.allowedMimeTypes.includes(
-        mime as (typeof GALLERY_STORAGE_CONFIG.allowedMimeTypes)[number]
-      )
-    ) {
+  const mime = contentType?.split(';')[0].trim().toLowerCase();
+  if (mime) {
+    if (!GALLERY_STORAGE_CONFIG.allowedMimeTypes.includes(mime as GalleryImageMimeType)) {
       throw new Error(
         `Invalid image type: ${mime}. Allowed types: ${GALLERY_STORAGE_CONFIG.allowedMimeTypes.join(', ')}`
       );
@@ -171,22 +165,20 @@ export async function saveImage(
     );
   }
 
-  // 7. Compress the image
-  const compressedBuffer = await compressForGallery(imageBuffer);
+  const preparedImage = prepareImageForStorage(
+    imageBuffer,
+    (mime as GalleryImageMimeType | undefined) ?? 'image/png',
+    metadata
+  );
 
-  // 8. Extract dimensions from compressed image
-  const compressedMetadata = await sharp(compressedBuffer).metadata();
-  const width = compressedMetadata.width ?? metadata.width ?? 0;
-  const height = compressedMetadata.height ?? metadata.height ?? 0;
-
-  // 9. Generate storage path: {user_id}/{uuid}.webp
-  const storagePath = `${userId}/${randomUUID()}.webp`;
+  // 9. Generate storage path: {user_id}/{uuid}.{extension}
+  const storagePath = `${userId}/${randomUUID()}.${preparedImage.extension}`;
 
   // 10. Upload to Supabase Storage
   const { error: uploadError } = await supabaseAdmin.storage
     .from(BUCKET_NAME)
-    .upload(storagePath, compressedBuffer, {
-      contentType: 'image/webp',
+    .upload(storagePath, preparedImage.buffer, {
+      contentType: preparedImage.contentType,
       cacheControl: '31536000', // 1 year cache
       upsert: false,
     });
@@ -202,9 +194,9 @@ export async function saveImage(
       user_id: userId,
       storage_path: storagePath,
       original_filename: metadata.filename,
-      file_size_bytes: compressedBuffer.length,
-      width,
-      height,
+      file_size_bytes: preparedImage.buffer.length,
+      width: preparedImage.width,
+      height: preparedImage.height,
       model_used: metadata.modelUsed ?? 'unknown',
       processing_mode: metadata.processingMode ?? 'both',
     })
@@ -227,36 +219,38 @@ export async function saveImage(
 }
 
 /**
- * Compress an image buffer for gallery storage
- * - Resizes to max 2048px while maintaining aspect ratio
- * - Converts to WebP format
- * - Quality 80
+ * Prepare an image buffer for gallery storage.
  *
  * @param buffer - Image data as buffer
- * @returns Compressed image buffer
+ * @returns Original image buffer
  */
 export async function compressForGallery(buffer: Buffer): Promise<Buffer> {
-  const image = sharp(buffer);
-  const metadata = await image.metadata();
+  return buffer;
+}
 
-  // Determine if resize is needed
-  const needsResize =
-    (metadata.width && metadata.width > COMPRESSION_CONFIG.maxDimension) ||
-    (metadata.height && metadata.height > COMPRESSION_CONFIG.maxDimension);
+function prepareImageForStorage(
+  imageBuffer: Buffer,
+  sourceContentType: GalleryImageMimeType,
+  metadata: ISaveImageMetadata
+): IPreparedGalleryImage {
+  return {
+    buffer: imageBuffer,
+    contentType: sourceContentType,
+    extension: extensionForMimeType(sourceContentType),
+    width: metadata.width ?? 1,
+    height: metadata.height ?? 1,
+  };
+}
 
-  let pipeline = image;
-
-  if (needsResize) {
-    pipeline = pipeline.resize(COMPRESSION_CONFIG.maxDimension, COMPRESSION_CONFIG.maxDimension, {
-      fit: 'inside',
-      withoutEnlargement: true,
-    });
+function extensionForMimeType(mimeType: GalleryImageMimeType): string {
+  switch (mimeType) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/webp':
+      return 'webp';
   }
-
-  // Convert to WebP with compression
-  const compressedBuffer = await pipeline.webp({ quality: COMPRESSION_CONFIG.quality }).toBuffer();
-
-  return compressedBuffer;
 }
 
 /**
@@ -303,13 +297,27 @@ export async function listImages(
   const images = (data as IGalleryImage[]) ?? [];
   const total = count ?? 0;
 
-  // Generate signed URLs for each image
-  const imagesWithUrls = await Promise.all(
+  // Generate signed URLs for each image. A single stale storage path should not
+  // make the whole gallery unavailable.
+  const signedUrlResults = await Promise.allSettled(
     images.map(async image => ({
       ...image,
       signed_url: await generateSignedUrl(image.storage_path),
     }))
   );
+  const imagesWithUrls = signedUrlResults.flatMap((result, index) => {
+    if (result.status === 'fulfilled') {
+      return [result.value];
+    }
+
+    const image = images[index];
+    console.error('Failed to generate gallery signed URL', {
+      imageId: image?.id,
+      storagePath: image?.storage_path,
+      error: result.reason instanceof Error ? result.reason.message : result.reason,
+    });
+    return [];
+  });
 
   return {
     images: imagesWithUrls,

--- a/server/services/galleryStorage.service.ts
+++ b/server/services/galleryStorage.service.ts
@@ -29,6 +29,12 @@ const BUCKET_NAME = GALLERY_STORAGE_CONFIG.bucketName;
  * Signed URL expiration time in seconds (1 hour)
  */
 const SIGNED_URL_EXPIRES_IN = 3600;
+const THUMBNAIL_TRANSFORM = {
+  width: 512,
+  height: 512,
+  resize: 'cover' as const,
+  quality: 70,
+};
 
 type GalleryImageMimeType = (typeof GALLERY_STORAGE_CONFIG.allowedMimeTypes)[number];
 
@@ -68,6 +74,14 @@ export interface ISaveImageResult {
   image: IGalleryImage;
   /** Signed URL for viewing (time-limited) */
   signedUrl: string;
+  /** Signed URL for gallery thumbnail (time-limited) */
+  thumbnailSignedUrl: string;
+}
+
+interface ISaveImageBufferInput {
+  buffer: Buffer;
+  contentType: string;
+  metadata: ISaveImageMetadata;
 }
 
 // =============================================================================
@@ -145,20 +159,42 @@ export async function saveImage(
     }
   }
 
-  // 5. Validate content-type (MIME check)
   const contentType = response.headers.get('content-type');
-  const mime = contentType?.split(';')[0].trim().toLowerCase();
-  if (mime) {
-    if (!GALLERY_STORAGE_CONFIG.allowedMimeTypes.includes(mime as GalleryImageMimeType)) {
-      throw new Error(
-        `Invalid image type: ${mime}. Allowed types: ${GALLERY_STORAGE_CONFIG.allowedMimeTypes.join(', ')}`
-      );
-    }
-  }
-
   const imageBuffer = Buffer.from(await response.arrayBuffer());
 
-  // 6. Double-check actual buffer size (in case content-length was missing/wrong)
+  return saveImageBufferInternal(userId, {
+    buffer: imageBuffer,
+    contentType: contentType ?? 'image/png',
+    metadata,
+  });
+}
+
+export async function saveUploadedImage(
+  userId: string,
+  fileBuffer: Buffer,
+  contentType: string,
+  metadata: ISaveImageMetadata
+): Promise<ISaveImageResult> {
+  const usage = await getUsage(userId);
+  if (!usage.can_save_more) {
+    throw new Error(
+      `Gallery limit exceeded. You have reached the maximum of ${usage.max_allowed} images for your plan.`
+    );
+  }
+
+  return saveImageBufferInternal(userId, {
+    buffer: fileBuffer,
+    contentType,
+    metadata,
+  });
+}
+
+async function saveImageBufferInternal(
+  userId: string,
+  { buffer: imageBuffer, contentType, metadata }: ISaveImageBufferInput
+): Promise<ISaveImageResult> {
+  const mime = parseAndValidateImageMime(contentType);
+
   if (imageBuffer.length > GALLERY_STORAGE_CONFIG.maxFileSizeBytes) {
     throw new Error(
       `Image size (${(imageBuffer.length / 1024 / 1024).toFixed(2)}MB) exceeds maximum allowed (${(GALLERY_STORAGE_CONFIG.maxFileSizeBytes / 1024 / 1024).toFixed(0)}MB)`
@@ -211,11 +247,30 @@ export async function saveImage(
 
   // 12. Generate signed URL for viewing
   const signedUrl = await generateSignedUrl(storagePath);
+  const thumbnailSignedUrl = await generateThumbnailSignedUrl(storagePath).catch(error => {
+    console.error('Failed to generate saved gallery thumbnail signed URL', {
+      storagePath,
+      error: error instanceof Error ? error.message : error,
+    });
+    return signedUrl;
+  });
 
   return {
     image: dbRecord as IGalleryImage,
     signedUrl,
+    thumbnailSignedUrl,
   };
+}
+
+function parseAndValidateImageMime(contentType: string): GalleryImageMimeType {
+  const mime = contentType.split(';')[0].trim().toLowerCase();
+  if (!GALLERY_STORAGE_CONFIG.allowedMimeTypes.includes(mime as GalleryImageMimeType)) {
+    throw new Error(
+      `Invalid image type: ${mime}. Allowed types: ${GALLERY_STORAGE_CONFIG.allowedMimeTypes.join(', ')}`
+    );
+  }
+
+  return mime as GalleryImageMimeType;
 }
 
 /**
@@ -300,10 +355,25 @@ export async function listImages(
   // Generate signed URLs for each image. A single stale storage path should not
   // make the whole gallery unavailable.
   const signedUrlResults = await Promise.allSettled(
-    images.map(async image => ({
-      ...image,
-      signed_url: await generateSignedUrl(image.storage_path),
-    }))
+    images.map(async image => {
+      const signedUrl = await generateSignedUrl(image.storage_path);
+      const thumbnailSignedUrl = await generateThumbnailSignedUrl(image.storage_path).catch(
+        error => {
+          console.error('Failed to generate gallery thumbnail signed URL', {
+            imageId: image.id,
+            storagePath: image.storage_path,
+            error: error instanceof Error ? error.message : error,
+          });
+          return signedUrl;
+        }
+      );
+
+      return {
+        ...image,
+        signed_url: signedUrl,
+        thumbnail_signed_url: thumbnailSignedUrl,
+      };
+    })
   );
   const imagesWithUrls = signedUrlResults.flatMap((result, index) => {
     if (result.status === 'fulfilled') {
@@ -441,6 +511,20 @@ async function generateSignedUrl(storagePath: string): Promise<string> {
 
   if (error) {
     throw new Error(`Failed to generate signed URL: ${error.message}`);
+  }
+
+  return data.signedUrl;
+}
+
+async function generateThumbnailSignedUrl(storagePath: string): Promise<string> {
+  const { data, error } = await supabaseAdmin.storage
+    .from(BUCKET_NAME)
+    .createSignedUrl(storagePath, SIGNED_URL_EXPIRES_IN, {
+      transform: THUMBNAIL_TRANSFORM,
+    });
+
+  if (error) {
+    throw new Error(`Failed to generate thumbnail signed URL: ${error.message}`);
   }
 
   return data.signedUrl;

--- a/shared/config/security.ts
+++ b/shared/config/security.ts
@@ -39,6 +39,10 @@ export const CSP_POLICY = {
     'https://accounts.google.com',
     'https://staticimgly.com', // @imgly/background-removal WASM model
     'https://analytics.ahrefs.com', // Ahrefs analytics API events
+    'https://replicate.delivery',
+    'https://*.replicate.delivery',
+    'https://replicate.com',
+    'https://*.replicate.com',
   ],
   'frame-src': [
     'https://js.stripe.com',

--- a/shared/types/gallery.types.ts
+++ b/shared/types/gallery.types.ts
@@ -31,6 +31,8 @@ export interface IGalleryImage {
   created_at: string;
   /** Signed URL for viewing (time-limited) */
   signed_url?: string;
+  /** Signed URL for gallery thumbnail (time-limited) */
+  thumbnail_signed_url?: string;
 }
 
 /**

--- a/tests/unit/bugfixes/analytics-event-whitelist.unit.spec.ts
+++ b/tests/unit/bugfixes/analytics-event-whitelist.unit.spec.ts
@@ -55,6 +55,8 @@ const ALLOWED_EVENTS = [
   // Batch limit events
   'batch_limit_modal_shown',
   'batch_limit_upgrade_clicked',
+  'batch_limit_quick_buy_clicked',
+  'batch_limit_see_plans_clicked',
   'batch_limit_partial_add_clicked',
   'batch_limit_modal_closed',
 
@@ -279,11 +281,37 @@ describe('Bug Fix: Analytics Event Whitelist', () => {
       const batchEvents = [
         'batch_limit_modal_shown',
         'batch_limit_upgrade_clicked',
+        'batch_limit_quick_buy_clicked',
+        'batch_limit_see_plans_clicked',
         'batch_limit_partial_add_clicked',
         'batch_limit_modal_closed',
       ];
       for (const eventName of batchEvents) {
         const result = eventSchema.safeParse({ eventName });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    test('accepts all emitted batch limit CTA events', () => {
+      const emittedBatchCtaEvents = [
+        'batch_limit_upgrade_clicked',
+        'batch_limit_quick_buy_clicked',
+        'batch_limit_see_plans_clicked',
+      ];
+      for (const eventName of emittedBatchCtaEvents) {
+        const result = eventSchema.safeParse({
+          eventName,
+          properties: {
+            limit: 5,
+            attempted: 10,
+            currentCount: 1,
+            availableSlots: 4,
+            serverEnforced: false,
+            userType: 'free',
+            copyVariant: 'value',
+            cta: 'quick_buy',
+          },
+        });
         expect(result.success).toBe(true);
       }
     });

--- a/tests/unit/client/batch-limit-modal.unit.spec.ts
+++ b/tests/unit/client/batch-limit-modal.unit.spec.ts
@@ -274,10 +274,34 @@ describe('BatchLimitModal', () => {
         limit: 1,
         attempted: 5,
         currentCount: 1,
+        availableSlots: 0,
         serverEnforced: false,
         userType: 'free',
         copyVariant: 'value',
         quickBuy: true,
+      });
+    });
+
+    it('quick buy emits canonical batch upgrade event', async () => {
+      mockGetVariant = vi.fn(() => 'value');
+      const { BatchLimitModal } =
+        await import('@/client/components/features/workspace/BatchLimitModal');
+      const { analytics } = await import('@client/analytics/analyticsClient');
+
+      render(React.createElement(BatchLimitModal, mockProps));
+
+      const quickBuyButton = screen.getByTestId('button-gradient');
+      fireEvent.click(quickBuyButton);
+
+      expect(analytics.track).toHaveBeenCalledWith('batch_limit_upgrade_clicked', {
+        limit: 1,
+        attempted: 5,
+        currentCount: 1,
+        availableSlots: 0,
+        serverEnforced: false,
+        userType: 'free',
+        copyVariant: 'value',
+        cta: 'quick_buy',
       });
     });
 
@@ -310,10 +334,34 @@ describe('BatchLimitModal', () => {
         limit: 1,
         attempted: 5,
         currentCount: 1,
+        availableSlots: 0,
         serverEnforced: false,
         userType: 'free',
         copyVariant: 'value',
         quickBuy: false,
+      });
+    });
+
+    it('see plans emits canonical batch upgrade event', async () => {
+      mockGetVariant = vi.fn(() => 'value');
+      const { BatchLimitModal } =
+        await import('@/client/components/features/workspace/BatchLimitModal');
+      const { analytics } = await import('@client/analytics/analyticsClient');
+
+      render(React.createElement(BatchLimitModal, mockProps));
+
+      const seePlansButton = screen.getByRole('button', { name: /See All Plans/i });
+      fireEvent.click(seePlansButton);
+
+      expect(analytics.track).toHaveBeenCalledWith('batch_limit_upgrade_clicked', {
+        limit: 1,
+        attempted: 5,
+        currentCount: 1,
+        availableSlots: 0,
+        serverEnforced: false,
+        userType: 'free',
+        copyVariant: 'value',
+        cta: 'see_plans',
       });
     });
   });

--- a/tests/unit/client/engagement-discount-banner.unit.spec.tsx
+++ b/tests/unit/client/engagement-discount-banner.unit.spec.tsx
@@ -28,13 +28,18 @@ vi.mock('@client/store/engagementDiscountStore', () => ({
     countdownEndTime: Date.now() + 30 * 60 * 1000, // 30 minutes from now
     hasTrackedImpression: false,
     setHasTrackedImpression: mockSetHasTrackedImpression,
+    discountSource: 'engagement',
   })),
 }));
 
-// Mock the DISCOUNT_TARGET_PACK
+// Mock the engagement discount config
 vi.mock('@shared/config/engagement-discount', () => ({
   DISCOUNT_TARGET_PACK: {
     credits: 500,
+  },
+  ENGAGEMENT_DISCOUNT_CONFIG: {
+    targetPackKey: 'credits_medium',
+    discountPercent: 20,
   },
   formatCountdown: (seconds: number) => {
     const mins = Math.floor(seconds / 60);
@@ -181,11 +186,13 @@ describe('EngagementDiscountBanner - Fix 1: Mobile Visibility', () => {
 
       expect(mockTrack).toHaveBeenCalledWith('engagement_discount_cta_clicked', {
         timeRemainingSeconds: expect.any(Number),
+        engagement_discount_source: expect.any(String),
+        targetPriceId: 'credits_medium',
       });
       expect(onClaimDiscount).toHaveBeenCalled();
     });
 
-    test('should track toast_shown impression and set hasTrackedImpression', async () => {
+    test('should track offer_shown impression and set hasTrackedImpression', async () => {
       const { useEngagementDiscountStore } = await import('@client/store/engagementDiscountStore');
       (useEngagementDiscountStore as ReturnType<typeof vi.fn>).mockReturnValue({
         offer: { discountPercent: 20, originalPriceCents: 999, discountedPriceCents: 799 },
@@ -194,21 +201,32 @@ describe('EngagementDiscountBanner - Fix 1: Mobile Visibility', () => {
         countdownEndTime: Date.now() + 30 * 60 * 1000,
         hasTrackedImpression: false,
         setHasTrackedImpression: mockSetHasTrackedImpression,
+        discountSource: 'engagement',
       });
 
       render(React.createElement(EngagementDiscountBanner, { onClaimDiscount: vi.fn() }));
 
       await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalledWith('engagement_discount_offer_shown', {
+          discountPercent: 20,
+          originalPriceCents: 999,
+          discountedPriceCents: 799,
+          engagement_discount_source: 'engagement',
+        });
+      });
+      // Legacy toast event should also be emitted
+      await waitFor(() => {
         expect(mockTrack).toHaveBeenCalledWith('engagement_discount_toast_shown', {
           discountPercent: 20,
           originalPriceCents: 999,
           discountedPriceCents: 799,
+          engagement_discount_source: 'engagement',
         });
       });
       expect(mockSetHasTrackedImpression).toHaveBeenCalledWith(true);
     });
 
-    test('should NOT track toast_shown when hasTrackedImpression is true', async () => {
+    test('should NOT track offer_shown when hasTrackedImpression is true', async () => {
       const { useEngagementDiscountStore } = await import('@client/store/engagementDiscountStore');
       (useEngagementDiscountStore as ReturnType<typeof vi.fn>).mockReturnValue({
         offer: { discountPercent: 20, originalPriceCents: 999, discountedPriceCents: 799 },
@@ -217,10 +235,14 @@ describe('EngagementDiscountBanner - Fix 1: Mobile Visibility', () => {
         countdownEndTime: Date.now() + 30 * 60 * 1000,
         hasTrackedImpression: true,
         setHasTrackedImpression: mockSetHasTrackedImpression,
+        discountSource: 'engagement',
       });
 
       render(React.createElement(EngagementDiscountBanner, { onClaimDiscount: vi.fn() }));
 
+      await waitFor(() => {
+        expect(mockTrack).not.toHaveBeenCalledWith('engagement_discount_offer_shown', expect.anything());
+      });
       await waitFor(() => {
         expect(mockTrack).not.toHaveBeenCalledWith('engagement_discount_toast_shown', expect.anything());
       });
@@ -240,6 +262,13 @@ describe('EngagementDiscountBanner - Fix 1: Mobile Visibility', () => {
       const dismissButton = screen.getByRole('button', { name: /dismiss offer/i });
       fireEvent.click(dismissButton);
 
+      await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalledWith('engagement_discount_offer_dismissed', {
+          timeRemainingSeconds: expect.any(Number),
+          engagement_discount_source: expect.any(String),
+        });
+      });
+      // Legacy toast event should also be emitted
       await waitFor(() => {
         expect(mockTrack).toHaveBeenCalledWith('engagement_discount_toast_dismissed', {
           timeRemainingSeconds: expect.any(Number),

--- a/tests/unit/client/hooks/useCheckoutSession.unit.spec.ts
+++ b/tests/unit/client/hooks/useCheckoutSession.unit.spec.ts
@@ -14,6 +14,7 @@ const {
   mockTrackStepViewed,
   mockTrackError,
   mockOnComplete,
+  mockAnalyticsTrack,
 } = vi.hoisted(() => ({
   mockCreateCheckoutSession: vi.fn(),
   mockClearCache: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockTrackStepViewed: vi.fn(),
   mockTrackError: vi.fn(),
   mockOnComplete: vi.fn(),
+  mockAnalyticsTrack: vi.fn(),
 }));
 
 // Stripe
@@ -70,6 +72,15 @@ vi.mock('next-intl', () => ({
       notConfigured: 'Stripe is not configured',
     };
     return map[key] ?? key;
+  },
+}));
+
+// Analytics
+vi.mock('@client/analytics', () => ({
+  analytics: {
+    track: mockAnalyticsTrack,
+    getDeviceId: vi.fn().mockReturnValue('mock-device-id'),
+    getAmplitudeSessionId: vi.fn().mockReturnValue(12345),
   },
 }));
 
@@ -217,6 +228,27 @@ describe('useCheckoutSession', () => {
       expect.any(String),
       'plan_selection'
     );
+  });
+
+  it('tracks checkout error with price and ui mode on failure', async () => {
+    mockCreateCheckoutSession.mockRejectedValue(new Error('Network failure'));
+
+    renderHook(() => useCheckoutSession(buildParams()));
+
+    await waitFor(() => {
+      expect(mockAnalyticsTrack).toHaveBeenCalledWith(
+        'checkout_error',
+        expect.objectContaining({
+          errorType: 'network_error',
+          errorMessage: 'Network failure',
+          step: 'plan_selection',
+          priceId: PRICE_ID,
+          trigger: 'unknown',
+          source: 'checkout_modal',
+          uiMode: expect.any(String),
+        })
+      );
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/workers/cron/README.md
+++ b/workers/cron/README.md
@@ -8,7 +8,9 @@ This worker runs on Cloudflare's edge and executes scheduled tasks:
 
 - **Webhook Recovery** - Every 15 minutes
 - **Expiration Check** - Every hour at :05
+- **Gallery Cleanup** - Daily at 12:00 AM UTC
 - **Full Reconciliation** - Daily at 3:05 AM UTC
+- **3-Kings Sitemap Refresh** - Daily at 4:30 AM UTC
 
 The worker calls the Next.js API endpoints with the proper authentication header.
 
@@ -133,11 +135,13 @@ node scripts/test-trigger.js webhook-recovery https://myimageupscaler-cron.worke
 
 ## Cron Schedules
 
-| Job                 | Pattern        | Frequency            | Endpoint                      |
-| ------------------- | -------------- | -------------------- | ----------------------------- |
-| Webhook Recovery    | `*/15 * * * *` | Every 15 minutes     | `/api/cron/recover-webhooks`  |
-| Expiration Check    | `5 * * * *`    | Hourly at :05        | `/api/cron/check-expirations` |
-| Full Reconciliation | `5 3 * * *`    | Daily at 3:05 AM UTC | `/api/cron/reconcile`         |
+| Job                     | Pattern        | Frequency             | Endpoint                           |
+| ----------------------- | -------------- | --------------------- | ---------------------------------- |
+| Webhook Recovery        | `*/15 * * * *` | Every 15 minutes      | `/api/cron/recover-webhooks`       |
+| Expiration Check        | `5 * * * *`    | Hourly at :05         | `/api/cron/check-expirations`      |
+| Gallery Cleanup         | `0 0 * * *`    | Daily at 12:00 AM UTC | `/api/cron/gallery-cleanup`        |
+| Full Reconciliation     | `5 3 * * *`    | Daily at 3:05 AM UTC  | `/api/cron/reconcile`              |
+| 3-Kings Sitemap Refresh | `30 4 * * *`   | Daily at 4:30 AM UTC  | `/api/cron/refresh-3kings-sitemap` |
 
 ## Troubleshooting
 

--- a/workers/cron/index.test.ts
+++ b/workers/cron/index.test.ts
@@ -36,7 +36,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '*/15 * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockResolvedValue({
@@ -70,7 +69,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '5 * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockResolvedValue({
@@ -96,7 +94,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '5 3 * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockResolvedValue({
@@ -118,11 +115,60 @@ describe('Cloudflare Cron Worker', () => {
       );
     });
 
+    it('should route 3-kings sitemap refresh cron pattern correctly', async () => {
+      const event = {
+        cron: '30 4 * * *',
+        scheduledTime: Date.now(),
+      } as ScheduledEvent;
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+      global.fetch = fetchMock;
+
+      await worker.scheduled(event, mockEnv, mockCtx as unknown);
+
+      expect(mockCtx.waitUntil).toHaveBeenCalled();
+      const waitUntilPromise = mockCtx.waitUntil.mock.calls[0][0];
+      await waitUntilPromise;
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/api/cron/refresh-3kings-sitemap',
+        expect.any(Object)
+      );
+    });
+
+    it('should route gallery cleanup cron pattern correctly', async () => {
+      const event = {
+        cron: '0 0 * * *',
+        scheduledTime: Date.now(),
+      } as ScheduledEvent;
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, usersProcessed: 2, imagesDeleted: 4 }),
+      });
+      global.fetch = fetchMock;
+
+      await worker.scheduled(event, mockEnv, mockCtx as unknown);
+
+      expect(mockCtx.waitUntil).toHaveBeenCalled();
+      const waitUntilPromise = mockCtx.waitUntil.mock.calls[0][0];
+      await waitUntilPromise;
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/api/cron/gallery-cleanup',
+        expect.any(Object)
+      );
+    });
+
     it('should handle unknown cron patterns', async () => {
       const event = {
         cron: '* * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -130,8 +176,7 @@ describe('Cloudflare Cron Worker', () => {
       await worker.scheduled(event, mockEnv, mockCtx as unknown);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Unknown cron pattern'),
-        '* * * * *'
+        expect.stringContaining('Unknown cron pattern: * * * * *')
       );
 
       consoleSpy.mockRestore();
@@ -141,7 +186,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '*/15 * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockResolvedValue({
@@ -171,7 +215,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '*/15 * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockRejectedValue(new Error('Network error'));
@@ -269,7 +312,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '*/15 * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockResolvedValue({
@@ -299,7 +341,6 @@ describe('Cloudflare Cron Worker', () => {
       const event = {
         cron: '*/15 * * * *',
         scheduledTime: Date.now(),
-         
       } as ScheduledEvent;
 
       const fetchMock = vi.fn().mockResolvedValue({

--- a/workers/cron/index.ts
+++ b/workers/cron/index.ts
@@ -28,7 +28,6 @@ export interface IEnv {
   CRON_SERVICE_NAME?: string;
 }
 
- 
 export default {
   /**
    * Scheduled event handler - triggered by cron patterns defined in wrangler.toml
@@ -54,6 +53,9 @@ export default {
     } else if (cronPattern === '30 4 * * *') {
       endpoint = '/api/cron/refresh-3kings-sitemap';
       jobName = '3-Kings Sitemap Refresh';
+    } else if (cronPattern === '0 0 * * *') {
+      endpoint = '/api/cron/gallery-cleanup';
+      jobName = 'Gallery Cleanup';
     } else {
       console.error(`[CRON] Unknown cron pattern: ${cronPattern}`);
       return;

--- a/workers/cron/scripts/test-trigger.js
+++ b/workers/cron/scripts/test-trigger.js
@@ -9,12 +9,16 @@
  *   node scripts/test-trigger.js webhook-recovery
  *   node scripts/test-trigger.js expiration-check
  *   node scripts/test-trigger.js reconciliation
+ *   node scripts/test-trigger.js refresh-3kings-sitemap
+ *   node scripts/test-trigger.js gallery-cleanup
  */
 
 const JOBS = {
   'webhook-recovery': '*/15 * * * *',
   'expiration-check': '5 * * * *',
   reconciliation: '5 3 * * *',
+  'refresh-3kings-sitemap': '30 4 * * *',
+  'gallery-cleanup': '0 0 * * *',
 };
 
 async function triggerCron(jobName, workerUrl = 'http://localhost:8787') {

--- a/workers/cron/wrangler.toml
+++ b/workers/cron/wrangler.toml
@@ -16,7 +16,9 @@ crons = [
   # Full reconciliation - daily at 3:05 AM UTC
   "5 3 * * *",
   # 3-Kings sitemap refresh - daily at 4:30 AM UTC
-  "30 4 * * *"
+  "30 4 * * *",
+  # Gallery cleanup - daily at midnight UTC
+  "0 0 * * *"
 ]
 
 # Environment Variables (non-sensitive defaults)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "myimageupscaler.com"
+name = "myimageupscaler"
 compatibility_date = "2024-11-20"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,17 @@
     tslib "^2.4.1"
     web-vitals "5.0.1"
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@asamuzakjp/css-color@^4.1.1":
   version "4.1.1"
   resolved "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz"
@@ -1646,12 +1657,12 @@
   resolved "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz"
   integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
 
-"@csstools/css-calc@^2.1.4":
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
   version "2.1.4"
   resolved "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz"
   integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
 
-"@csstools/css-color-parser@^3.1.0":
+"@csstools/css-color-parser@^3.0.9", "@csstools/css-color-parser@^3.1.0":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz"
   integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
@@ -1659,7 +1670,7 @@
     "@csstools/color-helpers" "^5.1.0"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.5":
+"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
@@ -1669,7 +1680,7 @@
   resolved "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.21.tgz"
   integrity sha512-plP8N8zKfEZ26figX4Nvajx8DuzfuRpLTqglQ5d0chfnt35Qt3X+m6ASZ+rG0D0kxe/upDVNwSIVJP5n4FuNfw==
 
-"@csstools/css-tokenizer@^3.0.4":
+"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
@@ -6188,6 +6199,14 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+cssstyle@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
+
 cssstyle@^5.3.4:
   version "5.3.5"
   resolved "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.5.tgz"
@@ -6206,6 +6225,14 @@ data-uri-to-buffer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
 
 data-urls@^6.0.0:
   version "6.0.0"
@@ -6273,7 +6300,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-decimal.js@^10.4.3, decimal.js@^10.6.0:
+decimal.js@^10.4.3, decimal.js@^10.5.0, decimal.js@^10.6.0:
   version "10.6.0"
   resolved "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz"
   integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
@@ -7971,6 +7998,13 @@ heic2any@^0.0.4:
   resolved "https://registry.yarnpkg.com/heic2any/-/heic2any-0.0.4.tgz#eddb8e6fec53c8583a6e18b65069bb5e8d19028a"
   integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
 html-encoding-sniffer@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz"
@@ -8088,6 +8122,13 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   version "0.7.2"
@@ -8549,6 +8590,32 @@ js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
+jsdom@^26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.1.0.tgz#ab5f1c1cafc04bd878725490974ea5e8bf0c72b3"
+  integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
+  dependencies:
+    cssstyle "^4.2.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.5.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.16"
+    parse5 "^7.2.1"
+    rrweb-cssom "^0.8.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.1.1"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.1.1"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
+
 jsdom@^27.4.0:
   version "27.4.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz"
@@ -8795,7 +8862,7 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lru-cache@^10.2.0:
+lru-cache@^10.2.0, lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -9804,6 +9871,11 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nwsapi@^2.2.16:
+  version "2.2.23"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.23.tgz#59712c3a88e6de2bb0b6ccc1070397267019cf6c"
+  integrity sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==
+
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
@@ -10027,7 +10099,7 @@ parse-ms@^2.1.0:
   resolved "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz"
   integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
 
-parse5@^7.0.0:
+parse5@^7.0.0, parse5@^7.2.1:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
   integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
@@ -10959,6 +11031,11 @@ router@^2.2.0:
     parseurl "^1.3.3"
     path-to-regexp "^8.0.0"
 
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
@@ -11781,10 +11858,22 @@ tinyrainbow@^3.0.3:
   resolved "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz"
   integrity sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==
 
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
 tldts-core@^7.0.19:
   version "7.0.19"
   resolved "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz"
   integrity sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
 
 tldts@^7.0.5:
   version "7.0.19"
@@ -11815,12 +11904,26 @@ totalist@^3.0.0:
   resolved "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz"
   integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
 
+tough-cookie@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
+  dependencies:
+    tldts "^6.1.32"
+
 tough-cookie@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz"
   integrity sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==
   dependencies:
     tldts "^7.0.5"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
 
 tr46@^6.0.0:
   version "6.0.0"
@@ -12364,15 +12467,35 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
 webidl-conversions@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz"
   integrity sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==
 
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0, whatwg-url@^14.1.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^15.0.0, whatwg-url@^15.1.0:
   version "15.1.0"


### PR DESCRIPTION
## Summary

Fixes #118 — Revenue-intent events show severe leaks in batch-limit checkout, checkout completion, upgrade prompts, and discount CTAs. Code inspection showed telemetry taxonomy mismatches that can make a working path look dead.

## Changes

### Phase 1: Telemetry Contract and Batch Event Repair
- `BatchLimitModal` now emits canonical `batch_limit_upgrade_clicked` with `cta: 'quick_buy' | 'see_plans'` from both upgrade CTAs
- Legacy `batch_limit_quick_buy_clicked` and `batch_limit_see_plans_clicked` preserved for backward compatibility
- Added missing events to analytics API allowlist
- Updated unit tests to assert canonical event emission

### Phase 2: Batch Paywall Checkout Handoff
- Checkout page now includes `originatingTrigger` and `attributionChain` in `checkout_opened` and `checkout_auth_required` events

### Phase 3: Checkout-to-Purchase Failure Audit and Diagnostics
- `useCheckoutSession` now tracks `checkout_error` with `trigger`, `source`, `priceId`, `uiMode`, `errorCode`, `stripeErrorType`, `stripeErrorParam`
- `/api/checkout` now logs structured diagnostics on Stripe session creation failures including `priceId`, `resolvedPriceType`, `checkoutMode`, `pricingRegion`, `discountPercent`, `uiMode`, and Stripe error `code/param/type`

### Phase 4: Upgrade Prompt Attribution
- `ModelGalleryModal` already preserves attribution chain correctly
- `PostDownloadPrompt` already sets `originatingTrigger`
- Checkout page now forwards `attributionChain` and `originatingTrigger`

### Phase 5: Discount Offer Visibility
- `EngagementDiscountBanner` now emits canonical `engagement_discount_offer_shown` and `engagement_discount_offer_dismissed`
- Legacy `engagement_discount_toast_shown` and `toast_dismissed` preserved
- CTA click now includes `engagement_discount_source` and `targetPriceId`

## Verification

- `npx vitest run tests/unit/client/batch-limit-modal.unit.spec.ts` — 23 passed
- `npx vitest run tests/unit/bugfixes/analytics-event-whitelist.unit.spec.ts` — 37 passed
- `npx vitest run tests/unit/client/engagement-discount-banner.unit.spec.tsx` — 10 passed
- `npx vitest run tests/unit/client/hooks/useCheckoutSession.unit.spec.ts` — 9 passed
- `npx tsc --noEmit` — clean
- Full unit test suite: 4374 passed, 5 failed (pre-existing unrelated failures in `CheckoutModal.anchor` and `CancelSubscriptionModal`)

## Success Metrics

- Batch-limit funnel: `batch_limit_upgrade_clicked -> checkout_opened` should be above 70% for authenticated users
- Checkout completion: `checkout_error` now includes enough fields to distinguish stale price IDs, network failures, auth failures, and Stripe declines
- Prompt attribution: `post_download_explore` direct funnel is replaced by assisted funnel reporting via `attributionChain`
- Discount: Discount offer CTA is visible and its CTA opens checkout with the correct trigger metadata
