### PR TITLE
Measure every credit wall encounter

### DIFF
--- a/app/api/analytics/event/route.ts
+++ b/app/api/analytics/event/route.ts
@@ -32,6 +32,7 @@ const ALLOWED_EVENTS = [
   'credit_pack_purchased',
   'credits_deducted',
   'credits_refunded',
+  'credit_wall_shown',
 
   // Image processing events
   'image_uploaded',

--- a/app/api/upscale/route.ts
+++ b/app/api/upscale/route.ts
@@ -58,6 +58,23 @@ function normalizePaidTier(tier: string | null | undefined): SubscriptionTier {
   return 'hobby';
 }
 
+async function trackCreditWallShown(
+  userId: string,
+  requiredCredits: number,
+  currentBalance: number
+): Promise<void> {
+  await trackServerEvent(
+    'credit_wall_shown',
+    {
+      source: 'server_402',
+      requiredCredits,
+      currentBalance,
+      deficit: Math.max(0, requiredCredits - currentBalance),
+    },
+    { apiKey: serverEnv.AMPLITUDE_API_KEY, userId }
+  );
+}
+
 /**
  * Directly call LLM analyzer for image analysis
  * Returns AI analysis result with tier and enhancement suggestions
@@ -827,6 +844,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         requiredCredits: creditCost,
         effectiveTotalCredits,
       });
+      await trackCreditWallShown(userId, creditCost, effectiveTotalCredits);
       const { body, status } = createErrorResponse(
         ErrorCodes.INSUFFICIENT_CREDITS,
         `You have insufficient credits. This operation requires ${creditCost} credit${creditCost > 1 ? 's' : ''}.`,
@@ -1032,6 +1050,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     if (error instanceof InsufficientCreditsError) {
       logFailure('insufficient_credits', { requiredCredits: creditCost });
       const availableCredits = error.availableCredits ?? effectiveTotalCredits ?? 1;
+      if (userId) {
+        await trackCreditWallShown(userId, creditCost, availableCredits);
+      }
       const { body, status } = createErrorResponse(
         ErrorCodes.INSUFFICIENT_CREDITS,
         `You have insufficient credits. This operation requires ${creditCost} credit${creditCost > 1 ? 's' : ''}.`,

--- a/client/components/features/workspace/BatchSidebar/ActionPanel.tsx
+++ b/client/components/features/workspace/BatchSidebar/ActionPanel.tsx
@@ -1,4 +1,5 @@
 import { IBatchItem, ProcessingStatus } from '@/shared/types/coreflow.types';
+import { analytics } from '@client/analytics';
 import { InsufficientCreditsModal } from '@client/components/stripe/InsufficientCreditsModal';
 import { Button } from '@client/components/ui/Button';
 import { Download, Loader2, Trash2, Wand2 } from 'lucide-react';
@@ -43,6 +44,12 @@ export const ActionPanel: React.FC<IActionPanelProps> = ({
 
   const handleProcessClick = () => {
     if (!hasEnoughCredits && pendingQueue.length > 0) {
+      analytics.track('credit_wall_shown', {
+        source: 'preflight_action_panel',
+        requiredCredits: totalCost,
+        currentBalance,
+        deficit: totalCost - currentBalance,
+      });
       setShowInsufficientModal(true);
       return;
     }

--- a/client/components/features/workspace/BatchSidebar/__tests__/ActionPanel.test.tsx
+++ b/client/components/features/workspace/BatchSidebar/__tests__/ActionPanel.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProcessingStatus } from '@/shared/types/coreflow.types';
+import { ActionPanel } from '../ActionPanel';
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock('@client/analytics', () => ({
+  analytics: { track },
+}));
+
+vi.mock('@client/components/stripe/InsufficientCreditsModal', () => ({
+  InsufficientCreditsModal: () => null,
+}));
+
+describe('ActionPanel credit wall analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should track the preflight action panel wall when credits are insufficient', () => {
+    const setShowInsufficientModal = vi.fn();
+    const onProcess = vi.fn();
+
+    render(
+      <ActionPanel
+        queue={[
+          {
+            id: 'item-1',
+            file: new File(['image'], 'image.png', { type: 'image/png' }),
+            previewUrl: 'blob:test',
+            processedUrl: null,
+            status: ProcessingStatus.IDLE,
+            progress: 0,
+          },
+        ]}
+        isProcessing={false}
+        batchProgress={null}
+        completedCount={0}
+        totalCost={3}
+        currentBalance={1}
+        onProcess={onProcess}
+        onDownloadAll={vi.fn()}
+        onClear={vi.fn()}
+        onUpgrade={vi.fn()}
+        showInsufficientModal={false}
+        setShowInsufficientModal={setShowInsufficientModal}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Process All/ }));
+
+    expect(onProcess).not.toHaveBeenCalled();
+    expect(setShowInsufficientModal).toHaveBeenCalledWith(true);
+    expect(track).toHaveBeenCalledWith('credit_wall_shown', {
+      source: 'preflight_action_panel',
+      requiredCredits: 3,
+      currentBalance: 1,
+      deficit: 2,
+    });
+  });
+});

--- a/client/components/features/workspace/Workspace.tsx
+++ b/client/components/features/workspace/Workspace.tsx
@@ -454,6 +454,12 @@ const Workspace: React.FC = () => {
 
     const requiredCredits = getRequiredCreditsForPendingQueue();
     if (requiredCredits > totalCredits) {
+      analytics.track('credit_wall_shown', {
+        source: 'preflight_batch',
+        requiredCredits,
+        currentBalance: totalCredits,
+        deficit: requiredCredits - totalCredits,
+      });
       openUpgradeModal(true, 'insufficient_credits', {
         requiredCredits,
         currentBalance: totalCredits,

--- a/client/components/features/workspace/__tests__/Workspace.test.tsx
+++ b/client/components/features/workspace/__tests__/Workspace.test.tsx
@@ -537,6 +537,7 @@ describe('Workspace Quality Tier Logic', () => {
   });
 
   test('should open dismissible upgrade modal when credits are insufficient', async () => {
+    const analyticsTrack = await getAnalyticsMock();
     mockTotalCredits = 0;
     mockBatchQueueState.queue = [
       {
@@ -553,6 +554,12 @@ describe('Workspace Quality Tier Logic', () => {
     fireEvent.click(screen.getByTestId('batch-sidebar-process'));
 
     expect(mockProcessBatch).not.toHaveBeenCalled();
+    expect(analyticsTrack).toHaveBeenCalledWith('credit_wall_shown', {
+      source: 'preflight_batch',
+      requiredCredits: 1,
+      currentBalance: 0,
+      deficit: 1,
+    });
     expect(screen.getByTestId('purchase-modal')).toHaveAttribute(
       'data-trigger',
       'insufficient_credits'

--- a/client/hooks/useBatchQueue.ts
+++ b/client/hooks/useBatchQueue.ts
@@ -8,7 +8,10 @@ import { useToastStore } from '@client/store/toastStore';
 import { useUserData, useUserStore } from '@client/store/userStore';
 import { BatchLimitError, FreeLimitExceededError, processImage } from '@client/utils/api-client';
 import { prepareFileForProcessing } from '@client/utils/upscale-file-preprocessing';
-import { getBatchLimit } from '@shared/config/subscription.utils';
+import {
+  calculateBatchProviderAwareCreditCost,
+  getBatchLimit,
+} from '@shared/config/subscription.utils';
 import { TIMEOUTS } from '@shared/config/timeouts.config';
 import { serializeError } from '@shared/utils/errors';
 import { useTranslations } from 'next-intl';
@@ -55,7 +58,7 @@ export const useBatchQueue = (): IUseBatchQueueReturn => {
   const t = useTranslations('workspace');
 
   // Get user subscription data
-  const { profile } = useUserData();
+  const { profile, totalCredits } = useUserData();
   const batchLimit = getBatchLimit(profile?.subscription_tier ?? null);
 
   // Cleanup object URLs on unmount
@@ -337,6 +340,10 @@ export const useBatchQueue = (): IUseBatchQueueReturn => {
         return;
       } else if (error instanceof Error && error.message.includes('insufficient credits')) {
         errorType = 'insufficient_credits';
+        const requiredCredits = calculateBatchProviderAwareCreditCost({
+          config,
+          items: [item],
+        }).totalCredits;
 
         // Track error_occurred event for insufficient credits
         analytics.track('error_occurred', {
@@ -346,6 +353,12 @@ export const useBatchQueue = (): IUseBatchQueueReturn => {
             fileName: item.file.name,
             fileSize: item.file.size,
           },
+        });
+        analytics.track('credit_wall_shown', {
+          source: 'midbatch',
+          requiredCredits,
+          currentBalance: totalCredits,
+          deficit: Math.max(0, requiredCredits - totalCredits),
         });
 
         // Show a specific error message for insufficient credits

--- a/server/analytics/types.ts
+++ b/server/analytics/types.ts
@@ -44,6 +44,13 @@ export interface ICreditPackProperties {
   currency?: string;
 }
 
+export interface ICreditWallShownProperties {
+  source: 'preflight_batch' | 'preflight_action_panel' | 'midbatch' | 'server_402';
+  requiredCredits: number;
+  currentBalance: number;
+  deficit: number;
+}
+
 export interface IImageUpscaledProperties {
   inputWidth: number;
   inputHeight: number;
@@ -667,6 +674,7 @@ export type IAnalyticsEventName =
   | 'revenue_support_contact'
   | 'credits_deducted'
   | 'credits_refunded'
+  | 'credit_wall_shown'
   // Image processing events
   | 'image_uploaded'
   | 'image_upscale_started'

--- a/tests/unit/api/upscale-free-limit.route.unit.spec.ts
+++ b/tests/unit/api/upscale-free-limit.route.unit.spec.ts
@@ -186,6 +186,16 @@ describe('POST /api/upscale free limit errors', () => {
     await expect(response.json()).resolves.toMatchObject({
       error: { code: 'INSUFFICIENT_CREDITS', details: { required: 1, available: 0 } },
     });
+    expect(mocks.track).toHaveBeenCalledWith(
+      'credit_wall_shown',
+      {
+        source: 'server_402',
+        requiredCredits: 1,
+        currentBalance: 0,
+        deficit: 1,
+      },
+      { apiKey: 'test-key', userId: 'user-1' }
+    );
   });
 
   it('keeps INSUFFICIENT_CREDITS for a paid user with zero current balance', async () => {
@@ -248,5 +258,15 @@ describe('POST /api/upscale free limit errors', () => {
     await expect(response.json()).resolves.toMatchObject({
       error: { code: 'INSUFFICIENT_CREDITS', details: { required: 1, available: 0 } },
     });
+    expect(mocks.track).toHaveBeenCalledWith(
+      'credit_wall_shown',
+      {
+        source: 'server_402',
+        requiredCredits: 1,
+        currentBalance: 0,
+        deficit: 1,
+      },
+      { apiKey: 'test-key', userId: 'user-1' }
+    );
   });
 });

--- a/tests/unit/bugfixes/analytics-event-whitelist.unit.spec.ts
+++ b/tests/unit/bugfixes/analytics-event-whitelist.unit.spec.ts
@@ -24,6 +24,7 @@ const ALLOWED_EVENTS = [
   'credit_pack_purchased',
   'credits_deducted',
   'credits_refunded',
+  'credit_wall_shown',
 
   // Image processing events
   'image_uploaded',
@@ -160,11 +161,30 @@ describe('Bug Fix: Analytics Event Whitelist', () => {
     });
 
     test('should include credit events', () => {
-      const creditEvents = ['credit_pack_purchased', 'credits_deducted', 'credits_refunded'];
+      const creditEvents = [
+        'credit_pack_purchased',
+        'credits_deducted',
+        'credits_refunded',
+        'credit_wall_shown',
+      ];
       for (const eventName of creditEvents) {
         const result = eventSchema.safeParse({ eventName });
         expect(result.success).toBe(true);
       }
+    });
+
+    test('should accept credit wall measurement properties', () => {
+      const result = eventSchema.safeParse({
+        eventName: 'credit_wall_shown',
+        properties: {
+          source: 'preflight_batch',
+          requiredCredits: 3,
+          currentBalance: 1,
+          deficit: 2,
+        },
+      });
+
+      expect(result.success).toBe(true);
     });
 
     test('should include error/limit events (server-side only)', () => {

--- a/tests/unit/client/hooks/useBatchQueue.credit-wall.unit.spec.tsx
+++ b/tests/unit/client/hooks/useBatchQueue.credit-wall.unit.spec.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_ENHANCEMENT_SETTINGS,
+  ProcessingStatus,
+  type IBatchItem,
+  type IUpscaleConfig,
+} from '@/shared/types/coreflow.types';
+
+const mocks = vi.hoisted(() => ({
+  processImage: vi.fn(),
+  showToast: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock('@client/analytics', () => ({
+  analytics: { track: mocks.track },
+}));
+
+vi.mock('@client/store/toastStore', () => ({
+  useToastStore: (selector: (state: { showToast: typeof mocks.showToast }) => unknown) =>
+    selector({ showToast: mocks.showToast }),
+}));
+
+vi.mock('@client/store/userStore', () => {
+  const useUserStore = vi.fn();
+  useUserStore.getState = () => ({ updateCreditsFromProcessing: vi.fn() });
+
+  return {
+    useUserData: () => ({ profile: { id: 'user-1' }, totalCredits: 0 }),
+    useUserStore,
+  };
+});
+
+vi.mock('@client/utils/api-client', () => ({
+  BatchLimitError: class BatchLimitError extends Error {},
+  FreeLimitExceededError: class FreeLimitExceededError extends Error {},
+  processImage: mocks.processImage,
+}));
+
+vi.mock('@client/utils/upscale-file-preprocessing', () => ({
+  prepareFileForProcessing: (file: File) => Promise.resolve({ file, resized: false }),
+}));
+
+vi.mock('@client/utils/file-validation', () => ({
+  loadImageDimensions: () => Promise.resolve({ width: 100, height: 100 }),
+}));
+
+vi.mock('@shared/config/subscription.utils', async importOriginal => {
+  const actual = await importOriginal<typeof import('@shared/config/subscription.utils')>();
+  return {
+    ...actual,
+    getBatchLimit: () => 5,
+  };
+});
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { useBatchQueue } from '@/client/hooks/useBatchQueue';
+
+describe('useBatchQueue credit wall analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should track the midbatch wall with its credit deficit', async () => {
+    mocks.processImage.mockRejectedValue(
+      new Error('You have insufficient credits. This operation requires 1 credit.')
+    );
+    const item: IBatchItem = {
+      id: 'item-1',
+      file: new File(['image'], 'image.png', { type: 'image/png' }),
+      previewUrl: 'blob:test',
+      processedUrl: null,
+      status: ProcessingStatus.IDLE,
+      progress: 0,
+      inputDimensions: { width: 100, height: 100 },
+    };
+    const config: IUpscaleConfig = {
+      qualityTier: 'quick',
+      scale: 2,
+      additionalOptions: DEFAULT_ENHANCEMENT_SETTINGS,
+    };
+    const { result } = renderHook(() => useBatchQueue());
+
+    await act(async () => {
+      await result.current.processSingleItem(item, config);
+    });
+
+    expect(mocks.track).toHaveBeenCalledWith('credit_wall_shown', {
+      source: 'midbatch',
+      requiredCredits: 1,
+      currentBalance: 0,
+      deficit: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Phase 1 measurement slice from `docs/PRDs/credit-wall-monetization-surface.md`.

- adds the `credit_wall_shown` analytics contract and client relay whitelist entry
- tracks pre-flight batch, action-panel, mid-batch, and authoritative server 402 encounters
- records `requiredCredits`, `currentBalance`, and `deficit` for every source
- preserves the existing dismissible purchase flow and rollback guardrails

## Why

Credit-wall traffic is currently undercounted because both pre-flight paths are silent, while the existing insufficient-credit error metric only represents mid-batch failures. This creates a clean baseline before any Phase 2 or Phase 3 behavior changes.

Per the PRD, this PR intentionally ships Phase 1 alone. Typed 402 preservation, toast/banner reframing, modal copy changes, and discount experiments remain out of scope until the baseline and dependencies are ready.

## Validation

- `yarn test:unit` — 344 files passed; 4,991 tests passed; 6 skipped
- `yarn verify` — passed (TypeScript, ESLint, ICU translations, schema validation)
- focused credit-wall suite — 5 files, 64 tests passed
- automated PRD checkpoint review — PASS
- `git diff --check` — passed

## Notes

The mid-batch event uses the client-side cost/balance estimate during Phase 1. The `server_402` event captures the authoritative required/current/deficit values; Phase 2 will preserve those typed values end-to-end on the client.
